### PR TITLE
gcc-15 fixes

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -21,7 +21,7 @@ fortran-regex.tag  = "1.1.2"
 jonquil.git = "https://github.com/toml-f/jonquil"
 jonquil.rev = "4fbd4cf34d577c0fd25e32667ee9e41bf231ece8"
 fortran-shlex.git = "https://github.com/perazz/fortran-shlex"
-fortran-shlex.tag = "2.0.0"
+fortran-shlex.tag = "2.0.1"
 
 [[test]]
 name = "cli-test"

--- a/src/fpm_pkg_config.f90
+++ b/src/fpm_pkg_config.f90
@@ -312,6 +312,9 @@ subroutine run_wrapper(wrapper,args,verbose,exitcode,cmd_success,screen_output)
     ! Test command
     call execute_command_line(command//redirect_str,exitstat=stat,cmdstat=cmdstat)
 
+    print *, '+ '//command//redirect_str
+    print *, '+ exited with ',stat,' and cmdstat=',cmdstat
+
     ! Command successful?
     if (present(cmd_success)) cmd_success = cmdstat==0
 

--- a/src/fpm_pkg_config.f90
+++ b/src/fpm_pkg_config.f90
@@ -312,9 +312,6 @@ subroutine run_wrapper(wrapper,args,verbose,exitcode,cmd_success,screen_output)
     ! Test command
     call execute_command_line(command//redirect_str,exitstat=stat,cmdstat=cmdstat)
 
-    print *, '+ '//command//redirect_str
-    print *, '+ exited with ',stat,' and cmdstat=',cmdstat
-
     ! Command successful?
     if (present(cmd_success)) cmd_success = cmdstat==0
 

--- a/src/fpm_pkg_config.f90
+++ b/src/fpm_pkg_config.f90
@@ -338,7 +338,7 @@ subroutine run_wrapper(wrapper,args,verbose,exitcode,cmd_success,screen_output)
            close(iunit,status='delete')
 
         else
-           call fpm_stop(1,'cannot read temporary file from successful MPI wrapper')
+           call fpm_stop(1,'cannot read temporary file from successful command: '//command)
         endif
 
     end if

--- a/src/metapackage/fpm_meta_hdf5.f90
+++ b/src/metapackage/fpm_meta_hdf5.f90
@@ -4,7 +4,7 @@ module fpm_meta_hdf5
     use fpm_filesystem, only: join_path
     use fpm_pkg_config, only: assert_pkg_config, pkgcfg_has_package, pkgcfg_list_all
     use fpm_meta_base, only: metapackage_t, destroy
-    use fpm_meta_util, only: add_pkg_config_compile_options, lib_get_trailing
+    use fpm_meta_util, only: add_pkg_config_compile_options, lib_get_trailing, add_strings
     use fpm_manifest_metapackages, only: metapackage_request_t
     use fpm_error, only: error_t, fatal_error
 
@@ -112,8 +112,8 @@ module fpm_meta_hdf5
                       inquire(file=this_lib%s,exist=found)
 
                       ! File exists, but it is not linked against
-                      if (found) this%link_libs = [this%link_libs, &
-                                                   string_t(this%link_libs(i)%s//trim(find_hl(k)))]
+                      if (found) call add_strings(this%link_libs, &
+                                                   string_t(this%link_libs(i)%s//trim(find_hl(k))))
 
                    end do add_missing
 

--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -867,7 +867,7 @@ contains
 
         do i=1,size(wrappers)
             if (present(verbose)) then
-                if (verbose .or. .true.) print *, '+ MPI <',language,'> test wrapper <',wrappers(i)%s,'>'
+                if (verbose) print *, '+ MPI <',language,'> test wrapper <',wrappers(i)%s,'>'
             endif
             works(i) = which_mpi_library(wrappers(i),compiler,verbose)
         end do

--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -12,6 +12,7 @@ module fpm_meta_mpi
         remove_newline_characters
     use fpm_environment, only: get_env, get_os_type, os_is_unix, OS_MACOS, OS_WINDOWS
     use fpm_meta_base, only: metapackage_t, destroy
+    use fpm_meta_util, only: add_strings
     use fpm_manifest_metapackages, only: metapackage_request_t
     use fpm_pkg_config, only: run_wrapper
     use shlex_module, only: shlex_split => split
@@ -851,34 +852,6 @@ contains
         call assert_mpi_wrappers('C++',cpp_wrappers,compiler)
 
     end subroutine mpi_wrappers
-
-    !> Add elements to a string array with a loop (gcc-15 bug on array initializer)
-    pure subroutine add_strings(list,new)
-        type(string_t), allocatable, intent(inout) :: list(:)
-        type(string_t), intent(in) :: new(:)
-
-        integer :: i,n,add
-        type(string_t), allocatable :: tmp(:)
-
-        if (allocated(list)) then 
-           n = size(list)
-        else
-           n = 0
-        endif     
-
-        add = size(new)
-        if (add<=0) return
-
-        allocate(tmp(n+add))
-        do i=1,n
-           tmp(i) = list(i)
-        end do   
-        do i=1,add
-           tmp(n+i) = new(i)
-        end do   
-        call move_alloc(from=tmp,to=list)
-
-    end subroutine add_strings    
 
     !> Filter out invalid/unavailable mpi wrappers
     subroutine assert_mpi_wrappers(language,wrappers,compiler,verbose)

--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -846,14 +846,15 @@ contains
 
         end select compiler_specific
 
-        call assert_mpi_wrappers(fort_wrappers,compiler)
-        call assert_mpi_wrappers(c_wrappers,compiler)
-        call assert_mpi_wrappers(cpp_wrappers,compiler)
+        call assert_mpi_wrappers('Fortran',fort_wrappers,compiler)
+        call assert_mpi_wrappers('C',c_wrappers,compiler)
+        call assert_mpi_wrappers('C++',cpp_wrappers,compiler)
 
     end subroutine mpi_wrappers
 
     !> Filter out invalid/unavailable mpi wrappers
-    subroutine assert_mpi_wrappers(wrappers,compiler,verbose)
+    subroutine assert_mpi_wrappers(language,wrappers,compiler,verbose)
+        character(*), intent(in) :: language
         type(string_t), allocatable, intent(inout) :: wrappers(:)
         type(compiler_t), intent(in) :: compiler
         logical, optional, intent(in) :: verbose
@@ -865,7 +866,7 @@ contains
 
         do i=1,size(wrappers)
             if (present(verbose)) then
-                if (verbose) print *, '+ MPI test wrapper <',wrappers(i)%s,'>'
+                if (verbose .or. .true.) print *, '+ MPI <',language,'> test wrapper <',wrappers(i)%s,'>'
             endif
             works(i) = which_mpi_library(wrappers(i),compiler,verbose)
         end do


### PR DESCRIPTION
### **User description**
See https://github.com/fortran-lang/fpm/pull/1150. 

Unfortunately it seems like array reallocation with the array constructor is broken in gcc-15 (`a = [a, b]`), that is what was causing the failing metapackage tests.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix GCC-15 compatibility by replacing array constructors with loop-based array expansion

- Add utility functions for safe string array concatenation

- Improve MPI wrapper debugging and error messages

- Bump fortran-shlex dependency to version 2.0.1


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fpm_pkg_config.f90</strong><dd><code>Enhanced debugging and error reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/fpm_pkg_config.f90

<li>Add verbose debugging output for command execution<br> <li> Improve error message to include failing command details


</details>


  </td>
  <td><a href="https://github.com/krystophny/fpm/pull/1/files#diff-3fb85e3a2e581117a89af9177dc5022524de60c718d2e68f1a19c5971e24f5f4">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fpm_meta_util.f90</strong><dd><code>Add utility functions for safe array expansion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/metapackage/fpm_meta_util.f90

<li>Add <code>add_strings_one</code> and <code>add_strings_many</code> subroutines<br> <li> Implement loop-based array expansion to avoid GCC-15 issues<br> <li> Create generic interface for string array concatenation


</details>


  </td>
  <td><a href="https://github.com/krystophny/fpm/pull/1/files#diff-bb6ffcbed259b3645a739e539cc4980d0c560c8719ee6c553246e18e944b8129">+58/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fpm_meta_hdf5.f90</strong><dd><code>Replace array constructor for GCC-15 compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/metapackage/fpm_meta_hdf5.f90

<li>Replace array constructor with <code>add_strings</code> utility function<br> <li> Import new <code>add_strings</code> function from <code>fpm_meta_util</code>


</details>


  </td>
  <td><a href="https://github.com/krystophny/fpm/pull/1/files#diff-21bc5a04c1cc39a62bf2366c7ee3cfe4107d38c46fcaee8f8aac14cbc284f15e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fpm_meta_mpi.f90</strong><dd><code>Replace array constructors and improve MPI debugging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/metapackage/fpm_meta_mpi.f90

<li>Replace multiple array constructors with <code>add_strings</code> calls<br> <li> Add language parameter to MPI wrapper assertion function<br> <li> Enable verbose output for MPI wrapper testing<br> <li> Import <code>add_strings</code> utility function


</details>


  </td>
  <td><a href="https://github.com/krystophny/fpm/pull/1/files#diff-971887bec5e90f4298ce3f3ba6fa04d8ed101d52dbc2f90bf8812b1bd5bbe185">+26/-24</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fpm.toml</strong><dd><code>Update fortran-shlex dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fpm.toml

- Bump fortran-shlex dependency from 2.0.0 to 2.0.1


</details>


  </td>
  <td><a href="https://github.com/krystophny/fpm/pull/1/files#diff-d4bdc7d73c8136485ef07b2e815923b887c9305fcc13210ca21e7c6ab8e8b4a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>