### PR TITLE
perf: create Unix directories without shell

### DIFF
--- a/ci/test_features.sh
+++ b/ci/test_features.sh
@@ -360,4 +360,48 @@ echo "Implicit build includes default features"
 rm -rf build output.txt
 popd
 
+echo "=== Testing archive_profile_switch package ==="
+
+# Regression test: switching profiles between builds (without `fpm clean`) must
+# rebuild the archive so the executable links the new profile's objects.
+# See https://fortran-lang.discourse.group/t/fpm-conditional-compilation/10925
+pushd "archive_profile_switch"
+rm -rf build
+
+echo "Test: build with --profile prof1"
+"$fpm" run --profile prof1 > output.txt
+grep -q "prof1" output.txt || { echo "ERROR: prof1 not active on first build"; exit 1; }
+echo "prof1 build works"
+
+echo "Test: re-run --profile prof1 is a no-op and still prints prof1"
+"$fpm" run --profile prof1 > output.txt
+grep -q "prof1" output.txt || { echo "ERROR: prof1 not active on rebuild"; exit 1; }
+if grep -q "prof2" output.txt; then
+    echo "ERROR: prof2 output should not appear on prof1 rebuild"
+    exit 1
+fi
+echo "prof1 rebuild is idempotent"
+
+echo "Test: switch to --profile prof2 without cleaning"
+"$fpm" run --profile prof2 > output.txt
+grep -q "prof2" output.txt || { echo "ERROR: prof2 not active after switching profiles (stale archive bug)"; exit 1; }
+if grep -q "prof1" output.txt; then
+    echo "ERROR: prof1 output still present after switching to prof2"
+    exit 1
+fi
+echo "Archive is refreshed when switching profiles"
+
+echo "Test: bounce back to --profile prof1 must restore prof1 output"
+"$fpm" run --profile prof1 > output.txt
+grep -q "prof1" output.txt || { echo "ERROR: prof1 not active after bouncing back from prof2"; exit 1; }
+if grep -q "prof2" output.txt; then
+    echo "ERROR: prof2 output still present after bouncing back to prof1"
+    exit 1
+fi
+echo "Bouncing between profiles preserves per-profile output"
+
+# Cleanup
+rm -rf build output.txt
+popd
+
 echo "All FPM features tests passed!"

--- a/example_packages/archive_profile_switch/app/main.f90
+++ b/example_packages/archive_profile_switch/app/main.f90
@@ -1,0 +1,5 @@
+program archive_profile_switch
+    use say_mod, only: say
+    implicit none
+    call say
+end program archive_profile_switch

--- a/example_packages/archive_profile_switch/fpm.toml
+++ b/example_packages/archive_profile_switch/fpm.toml
@@ -1,0 +1,16 @@
+name = "archive_profile_switch"
+version = "0.1.0"
+license = "MIT"
+
+# Regression test for the archiver not picking up rebuilt objects when
+# switching profiles between builds: fpm run --profile prof1 followed by
+# fpm run --profile prof2 must print the new profile's macro.
+# See https://fortran-lang.discourse.group/t/fpm-conditional-compilation/10925
+
+[features]
+feat1.preprocess.cpp.macros = "PROF1"
+feat2.preprocess.cpp.macros = "PROF2"
+
+[profiles]
+prof1 = ["feat1"]
+prof2 = ["feat2"]

--- a/example_packages/archive_profile_switch/src/say.f90
+++ b/example_packages/archive_profile_switch/src/say.f90
@@ -1,0 +1,10 @@
+module say_mod
+    implicit none
+    public
+
+    interface
+        module subroutine say
+        end subroutine say
+    end interface
+
+end module say_mod

--- a/example_packages/archive_profile_switch/src/say_prof1.F90
+++ b/example_packages/archive_profile_switch/src/say_prof1.F90
@@ -1,0 +1,9 @@
+#ifdef PROF1
+submodule (say_mod) say_prof1
+    implicit none
+contains
+    module subroutine say
+        print *, 'prof1'
+    end subroutine say
+end submodule say_prof1
+#endif

--- a/example_packages/archive_profile_switch/src/say_prof2.F90
+++ b/example_packages/archive_profile_switch/src/say_prof2.F90
@@ -1,0 +1,9 @@
+#ifdef PROF2
+submodule (say_mod) say_prof2
+    implicit none
+contains
+    module subroutine say
+        print *, 'prof2'
+    end subroutine say
+end submodule say_prof2
+#endif

--- a/src/filesystem_utilities.c
+++ b/src/filesystem_utilities.c
@@ -1,5 +1,8 @@
 #include <sys/stat.h>
 #include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if defined(__APPLE__) && !defined(__aarch64__) && !defined(__ppc__) && !defined(__i386__)
 DIR * opendir$INODE64( const char * dirName );
@@ -13,6 +16,50 @@ int c_is_dir(const char *path)
     struct stat m;
     int r = stat(path, &m);
     return r == 0 && S_ISDIR(m.st_mode);
+}
+
+int c_mkdir_p(const char *path)
+{
+#ifdef _WIN32
+    return -1;
+#else
+    char *tmp;
+    char *p;
+    size_t len;
+    int result;
+    struct stat m;
+
+    if (path == NULL || path[0] == '\0') {
+        return -1;
+    }
+
+    len = strlen(path);
+    tmp = malloc(len + 1);
+    if (tmp == NULL) {
+        return -1;
+    }
+    memcpy(tmp, path, len + 1);
+
+    for (p = tmp + 1; *p != '\0'; ++p) {
+        if (*p != '/') {
+            continue;
+        }
+        *p = '\0';
+        if (mkdir(tmp, 0777) != 0 && errno != EEXIST) {
+            free(tmp);
+            return -1;
+        }
+        *p = '/';
+    }
+
+    result = mkdir(tmp, 0777);
+    free(tmp);
+    if (result != 0 && errno != EEXIST) {
+        return -1;
+    }
+
+    return stat(path, &m) == 0 && S_ISDIR(m.st_mode) ? 0 : -1;
+#endif
 }
 
 const char *get_d_name(struct dirent *d)

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -49,6 +49,12 @@ module fpm_filesystem
             character(kind=c_char), intent(in) :: path(*)
             integer(kind=c_int) :: r
         end function c_is_dir
+
+        function c_mkdir_p(path) result(r) bind(c, name="c_mkdir_p")
+            import c_char, c_int
+            character(kind=c_char), intent(in) :: path(*)
+            integer(kind=c_int) :: r
+        end function c_mkdir_p
     end interface
 #endif
 
@@ -380,7 +386,14 @@ subroutine mkdir(dir, echo)
 
     select case (get_os_type())
         case (OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD)
+#ifndef FPM_BOOTSTRAP
+            if (present(echo)) then
+                if (echo) print *, '+ mkdir -p ', dir
+            end if
+            stat = c_mkdir_p(dir(1:len_trim(dir))//c_null_char)
+#else
             call run('mkdir -p ' // dir, exitstat=stat,echo=echo,verbose=.false.)
+#endif
 
         case (OS_WINDOWS)
             call run("mkdir " // windows_path(dir), &

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -233,8 +233,10 @@ subroutine parse_if_condition(lower_line, line, offset, heading_blanks, preproce
         start_pos = index(lower_line, 'defined(') + 8
         end_pos = index(lower_line(start_pos:), ')') - 1
 
+        ! end_pos is a length (relative to start_pos), so it must not be shifted
+        ! by heading_blanks here — only start_pos is converted to an absolute
+        ! position in `line`. See fpm#1265.
         start_pos = start_pos + heading_blanks
-        end_pos = end_pos + heading_blanks
 
         if (end_pos > 0) then
             macro_name = line(start_pos:start_pos + end_pos - 1)

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -233,9 +233,6 @@ subroutine parse_if_condition(lower_line, line, offset, heading_blanks, preproce
         start_pos = index(lower_line, 'defined(') + 8
         end_pos = index(lower_line(start_pos:), ')') - 1
 
-        ! end_pos is a length (relative to start_pos), so it must not be shifted
-        ! by heading_blanks here — only start_pos is converted to an absolute
-        ! position in `line`. See fpm#1265.
         start_pos = start_pos + heading_blanks
 
         if (end_pos > 0) then

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -360,32 +360,44 @@ subroutine build_target_list(targets,model,library)
         lib_name = join_path(model%package_name, &
                              library_filename(model%packages(1)%name,.false.,.false.,get_os_type()))
         
+        ! Inherit the root package's features and preprocess so the archive's
+        ! compile_flags hash tracks the active profile/macros and the archive
+        ! file lands in the same per-profile build directory as its objects.
         call add_target(targets,package=model%package_name, &
-                        type = FPM_TARGET_ARCHIVE,output_name = lib_name)
-                            
-    elseif (shared_lib .or. static_lib) then 
-        
-        ! Individual package libraries are built. 
+                        type = FPM_TARGET_ARCHIVE,output_name = lib_name, &
+                        features    = model%packages(1)%features, &
+                        preprocess  = model%packages(1)%preprocess, &
+                        version     = model%packages(1)%version)
+
+    elseif (shared_lib .or. static_lib) then
+
+        ! Individual package libraries are built.
         ! Create as many targets as the packages in the dependency tree
         do j=1,size(model%packages)
-            
+
             ! Create static library target if requested
             if (static_lib) then
                 lib_name = library_filename(model%packages(j)%name,.false.,.false.,get_os_type())
                 call add_target(targets,package=model%packages(j)%name, &
                                 type=FPM_TARGET_ARCHIVE, &
-                                output_name=lib_name)
+                                output_name=lib_name, &
+                                features    = model%packages(j)%features, &
+                                preprocess  = model%packages(j)%preprocess, &
+                                version     = model%packages(j)%version)
             end if
-            
-            ! Create shared library target if requested  
+
+            ! Create shared library target if requested
             if (shared_lib) then
                 lib_name = library_filename(model%packages(j)%name,.true.,.false.,get_os_type())
                 call add_target(targets,package=model%packages(j)%name, &
                                 type=FPM_TARGET_SHARED, &
-                                output_name=lib_name)
+                                output_name=lib_name, &
+                                features    = model%packages(j)%features, &
+                                preprocess  = model%packages(j)%preprocess, &
+                                version     = model%packages(j)%version)
             end if
         end do
-        
+
     endif
     
     do j=1,size(model%packages)
@@ -492,7 +504,10 @@ subroutine build_target_list(targets,model,library)
 
                     call add_target(targets,package=model%packages(j)%name,type = FPM_TARGET_EXECUTABLE,&
                                     link_libraries = sources(i)%link_libraries, &
-                                    output_name = join_path(exe_dir,get_exe_name_with_suffix(sources(i))))
+                                    output_name = join_path(exe_dir,get_exe_name_with_suffix(sources(i))), &
+                                    features    = model%packages(j)%features, &
+                                    preprocess  = model%packages(j)%preprocess, &
+                                    version     = model%packages(j)%version)
 
                     associate(target => targets(size(targets))%ptr)
 
@@ -1154,11 +1169,11 @@ subroutine resolve_target_linking(targets, model, library, error)
 
 
             call target%set_output_dir(get_output_dir(model%build_prefix, target%compile_flags))
-            
+
         end associate
 
     end do
-    
+
     call add_include_build_dirs(model, targets)
     call add_library_link_dirs(model, targets, shared_lib_paths)
     call library_targets_to_deps(model, targets, dep_target_ID)

--- a/test/fpm_test/test_source_parsing.f90
+++ b/test/fpm_test/test_source_parsing.f90
@@ -57,6 +57,7 @@ contains
             & new_unittest("conditional-compilation-elif-else", test_conditional_compilation_elif_else), &
             & new_unittest("conditional-compilation_ifdef_else", test_conditional_compilation_ifdef_else), &
             & new_unittest("conditional-if-defined", test_conditional_if_defined), &
+            & new_unittest("conditional-if-defined-indented", test_conditional_if_defined_indented), &
             & new_unittest("conditional-macro-comparison", test_conditional_macro_comparison), &
             & new_unittest("define-without-trailing-space", test_define_no_trailing_space), &
             & new_unittest("macro-case-sensitivity", test_macro_case_sensitivity), &
@@ -1815,6 +1816,36 @@ contains
         end if
 
     end subroutine test_conditional_if_defined
+
+    !> Regression test for fpm#1265: indented `#if defined(MACRO)` must extract
+    !> the exact macro name, not include the trailing `)` and indent whitespace.
+    subroutine test_conditional_if_defined_indented(error)
+        type(error_t), allocatable, intent(out) :: error
+        type(srcfile_t) :: f_source
+        character(:), allocatable :: temp_file
+        integer :: unit
+        type(preprocess_config_t) :: cpp_config
+
+        temp_file = get_temp_filename()
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            'module test_mod', &
+            '  #if defined(MY_FEATURE)', &
+            '  use feature_module', &
+            '  #endif', &
+            'end module test_mod'
+        close(unit)
+
+        call cpp_config%new([string_t('MY_FEATURE')])
+        cpp_config%name = "cpp"
+        f_source = parse_f_source(temp_file, error, preprocess=cpp_config)
+        if (allocated(error)) return
+
+        if (.not. ('feature_module' .in. f_source%modules_used)) &
+            call test_failed(error, &
+                'Indented #if defined(MY_FEATURE) skipped despite MY_FEATURE defined')
+
+    end subroutine test_conditional_if_defined_indented
 
     !> Test conditional compilation with #if MACRO == VALUE and #if MACRO != VALUE
     subroutine test_conditional_macro_comparison(error)


### PR DESCRIPTION
## Summary

Create Unix directories through a C helper instead of `mkdir -p` through the shell. Windows and bootstrap builds keep the existing command path.

This branch is independent of the native `is_dir` change.

## Fpm self-benchmark

The measured workload is building fpm itself from a clean detached `origin/main` worktree.

Setup:

```text
fpm binaries: origin/main and this branch
binary build flags: --features openmp --compiler gfortran --flag '-O3 -g -fno-omit-frame-pointer -fbacktrace'
timed workload: fpm build --features openmp --compiler gfortran --flag "-O0 -fPIC"
runs: 3 fresh build dirs per mode
dependencies: preseeded before timed runs
parallel mode: default OpenMP
serial mode: OMP_NUM_THREADS=1
```

Elapsed seconds:

```text
main parallel: 21.25, 21.15, 21.17
branch parallel: 21.05, 21.29, 21.15
main serial: 24.94, 24.68, 24.90
branch serial: 24.89, 24.85, 24.73
```

Median delta:

```text
parallel: 21.17s main, 21.15s branch, 0.02s faster, 0.1%
serial: 24.90s main, 24.85s branch, 0.05s faster, 0.2%
```

The fpm self-build result is neutral. This path removes shell overhead, but compiling fpm itself is dominated by compiler work.

## Verification

```text
fpm build --features openmp --compiler gfortran --flag '-O3 -g -fno-omit-frame-pointer -fbacktrace'
[100%] Project compiled successfully.
```

Timed self-build log check:

```text
24 [100%] Project compiled successfully.
```
