### PR TITLE
feat: run link and archive in parallel via argv spawn

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1475,61 +1475,68 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
         stat = merge(-1,0,allocated(error))
     endif
 
-contains
-
-    !> Split a command fragment into argv tokens with the OS-native lexer and
-    !> append them to argv. fortran-shlex is not reentrant, so the split runs
-    !> in a critical region. join_spaced/keep_quotes apply to the POSIX lexer;
-    !> the Windows lexer already returns final argv tokens.
-    subroutine split_append(argv, str, join_spaced, keep_quotes, ok)
-        type(string_t), allocatable, intent(inout) :: argv(:)
-        character(len=*), intent(in) :: str
-        logical, intent(in) :: join_spaced, keep_quotes
-        logical, intent(inout) :: ok
-
-        character(len=:), allocatable :: parts(:)
-        integer :: k
-
-        if (.not.ok) return
-
-        !$omp critical(fpm_shlex_split)
-        if (os_is_unix()) then
-            parts = sh_split(str, join_spaced=join_spaced, keep_quotes=keep_quotes, success=ok)
-        else
-            parts = ms_split(str, success=ok)
-        end if
-        !$omp end critical(fpm_shlex_split)
-        if (.not.ok) return
-
-        do k = 1, size(parts)
-            if (len_trim(parts(k)) == 0) cycle
-            if (os_is_unix()) then
-                call add_strings(argv, string_t(clean_shlex_token(parts(k))))
-            else
-                call add_strings(argv, string_t(trim(parts(k))))
-            end if
-        end do
-    end subroutine split_append
-
-    function clean_shlex_token(token) result(clean)
-        character(len=*), intent(in) :: token
-        character(len=:), allocatable :: clean
-
-        integer :: j
-
-        clean = ""
-        do j = 1, len_trim(token)
-            select case (token(j:j))
-            case ("'", '"')
-                cycle
-            case default
-                clean = clean//token(j:j)
-            end select
-        end do
-        clean = trim(adjustl(clean))
-    end function clean_shlex_token
-
 end subroutine compile_fortran
+
+!> Split a command fragment into argv tokens with the OS-native lexer and
+!> append them to argv. fortran-shlex is not reentrant, so the split runs
+!> in a critical region. join_spaced/keep_quotes apply to the POSIX lexer;
+!> the Windows lexer already returns final argv tokens.
+subroutine split_append(argv, str, join_spaced, keep_quotes, ok)
+    type(string_t), allocatable, intent(inout) :: argv(:)
+    character(len=*), intent(in) :: str
+    logical, intent(in) :: join_spaced, keep_quotes
+    logical, intent(inout) :: ok
+
+    character(len=:), allocatable :: parts(:)
+    integer :: k
+
+    if (.not.ok) return
+
+    !$omp critical(fpm_shlex_split)
+    if (os_is_unix()) then
+        parts = sh_split(str, join_spaced=join_spaced, keep_quotes=keep_quotes, success=ok)
+    else
+        parts = ms_split(str, success=ok)
+    end if
+    !$omp end critical(fpm_shlex_split)
+    if (.not.ok) return
+
+    do k = 1, size(parts)
+        if (len_trim(parts(k)) == 0) cycle
+        if (os_is_unix()) then
+            call add_strings(argv, string_t(clean_shlex_token(parts(k))))
+        else
+            call add_strings(argv, string_t(trim(parts(k))))
+        end if
+    end do
+end subroutine split_append
+
+function clean_shlex_token(token) result(clean)
+    character(len=*), intent(in) :: token
+    character(len=:), allocatable :: clean
+
+    integer :: j
+
+    clean = ""
+    do j = 1, len_trim(token)
+        select case (token(j:j))
+        case ("'", '"')
+            cycle
+        case default
+            clean = clean//token(j:j)
+        end select
+    end do
+    clean = trim(adjustl(clean))
+end function clean_shlex_token
+
+!> True when the string ends in a blank (space or tab), i.e. its last character
+!> separates it from anything concatenated after it.
+logical function ends_with_blank(str)
+    character(len=*), intent(in) :: str
+    ends_with_blank = .false.
+    if (len(str) > 0) ends_with_blank = (str(len(str):len(str)) == ' ' &
+        & .or. str(len(str):len(str)) == char(9))
+end function ends_with_blank
 
 
 !> Compile a C object
@@ -1644,7 +1651,8 @@ subroutine link_executable(self, output, args, log_file, stat, dry_run)
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
-    logical :: mock
+    type(string_t), allocatable :: argv(:)
+    logical :: mock, tokenized
 
     ! Initialize intent(out) status so the mock path returns a defined value.
     stat = 0
@@ -1653,16 +1661,27 @@ subroutine link_executable(self, output, args, log_file, stat, dry_run)
     mock = .false.
     if (present(dry_run)) mock = dry_run
 
-    ! Set command
+    ! Shell fallback string plus the argv token list. Exec via argv spawn
+    ! (fork-safe under OpenMP) so the link can run in parallel; the previous
+    ! run() needed critical(run_command) only because the shell fork is not.
     command = self%fc // " " // args // " -o " // output
+    tokenized = .true.
+    call split_append(argv, self%fc, .false., .false., tokenized)
+    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
-    ! Execute command. Serialize concurrent forks: gfortran's
-    ! execute_command_line uses system(3) which forks, and concurrent
-    ! fork from OpenMP threads is documented non-thread-safe.
     if (.not.mock) then
-        !$omp critical (run_command)
-        call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
-        !$omp end critical (run_command)
+        if (tokenized) then
+            call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+        else
+            ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+            !$omp critical (run_command)
+            call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+            !$omp end critical (run_command)
+        end if
     end if
 
 end subroutine link_executable
@@ -1683,7 +1702,8 @@ subroutine link_shared(self, output, args, log_file, stat, dry_run)
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
-    logical :: mock
+    type(string_t), allocatable :: argv(:)
+    logical :: mock, tokenized
     character(len=:), allocatable :: shared_flag
 
     ! Initialize intent(out) status so the mock path returns a defined value.
@@ -1695,11 +1715,24 @@ subroutine link_shared(self, output, args, log_file, stat, dry_run)
     shared_flag = get_shared_flag(self)
 
     command = self%fc // " " // shared_flag // " " // args // " -o " // output
+    tokenized = .true.
+    call split_append(argv, self%fc, .false., .false., tokenized)
+    if (tokenized .and. len_trim(shared_flag) > 0) call split_append(argv, shared_flag, .true., .true., tokenized)
+    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
     if (.not.mock) then
-        !$omp critical (run_command)
-        call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
-        !$omp end critical (run_command)
+        if (tokenized) then
+            call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+        else
+            ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+            !$omp critical (run_command)
+            call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+            !$omp end critical (run_command)
+        end if
     end if
 
 end subroutine link_shared
@@ -1723,7 +1756,10 @@ subroutine make_archive(self, output, args, log_file, stat, dry_run)
     !> Optional mocking
     logical, optional, intent(in) :: dry_run
 
-    logical :: mock
+    character(len=:), allocatable :: command
+    type(string_t), allocatable :: argv(:)
+    logical :: mock, tokenized
+    integer :: i
 
     ! Initialize intent(out) status so the mock path returns a defined value.
     stat = 0
@@ -1734,20 +1770,47 @@ subroutine make_archive(self, output, args, log_file, stat, dry_run)
 
     if (mock) return
 
+    ! Build the argv token list: archiver + flags, the archive name, then the
+    ! object files (already individual tokens). argv spawn is fork-safe under
+    ! OpenMP, so the archive runs without critical(run_command), and it has no
+    ! shell command-length ceiling.
+    tokenized = .true.
+    call split_append(argv, self%ar, .false., .false., tokenized)
+    if (tokenized) then
+        ! Reproduce `self%ar // output`. self%ar is concatenated directly with
+        ! output, so when it ends without a separator (MSVC `lib /OUT:`) the
+        ! name glues onto the last flag token; GNU `ar -rs ` ends in a space and
+        ! takes output as its own token.
+        if (size(argv) > 0 .and. .not.ends_with_blank(self%ar)) then
+            argv(size(argv))%s = argv(size(argv))%s // output
+        else
+            call add_strings(argv, string_t(output))
+        end if
+    end if
+
     if (self%use_response_file) then
         call write_response_file(output//".resp" , args)
-        !$omp critical (run_command)
-        call run(self%ar // output // " @" // output//".resp", echo=self%echo, &
-            &  verbose=self%verbose, redirect=log_file, exitstat=stat)
-        !$omp end critical (run_command)
-        call delete_file_win32(output//".resp")
-
+        command = self%ar // output // " @" // output//".resp"
+        if (tokenized) call add_strings(argv, string_t("@"//output//".resp"))
     else
+        command = self%ar // output // " " // string_cat(args, " ")
+        if (tokenized) then
+            do i = 1, size(args)
+                call add_strings(argv, args(i))
+            end do
+        end if
+    end if
+
+    if (tokenized) then
+        call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+    else
+        ! Tokenization failed; serialize the shell fork (not concurrency-safe).
         !$omp critical (run_command)
-        call run(self%ar // output // " " // string_cat(args, " "), &
-            & echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+        call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
         !$omp end critical (run_command)
     end if
+
+    if (self%use_response_file) call delete_file_win32(output//".resp")
 
     contains
         subroutine delete_file_win32(file)

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1124,13 +1124,19 @@ subroutine run_argv(args,echo,exitstat,verbose,redirect)
             redirect_file//c_null_char)
 #else
     else
+        !$omp critical (run_command)
         call run(command, echo=.false., verbose=verbose_local, redirect=redirect_file, exitstat=stat)
+        !$omp end critical (run_command)
 #endif
     end if
 
     ! Fall back to the shell if the argv spawn was unavailable or failed (stat < 0).
+    ! The shell forks, which is not safe to call concurrently from OpenMP
+    ! threads, so this rare path stays serialized.
     if (stat < 0) then
+        !$omp critical (run_command)
         call run(command, echo=.false., verbose=verbose_local, redirect=redirect_file, exitstat=stat)
+        !$omp end critical (run_command)
     end if
 
     if (verbose_local.and.present(redirect)) then


### PR DESCRIPTION
Stacked on #6 (argv compiler spawn). Base this PR on `perf/argv-fortran-compile`.

## What

Make `link` and `archive` run in parallel under OpenMP.

Commit `bb891e3f` wrapped `link_executable` / `link_shared` / `make_archive` in
`critical(run_command)` because their `run()` shells out, and concurrent
`fork()` from OpenMP threads is not safe (observed: ar argument truncation on
macOS CI). That serializes all linking and archiving.

This change execs them through `run_argv` instead, which spawns by `argv`
(`posix_spawn` on Unix, `CreateProcess` on Windows) and is fork-safe, so the
`critical(run_command)` is dropped and link/archive run concurrently.

## Change

- `link_executable` / `link_shared` / `make_archive` build an `argv` token list
  and exec via `run_argv`; the `critical(run_command)` is removed from the
  fork-safe spawn path.
- The rare shell fallbacks (tokenization failure, and `run_argv`'s own
  `stat < 0` / bootstrap fallback) stay wrapped in `critical(run_command)`,
  since those still `fork()`.
- `make_archive` reproduces `self%ar // output` exactly: the archive name glues
  onto the last flag token for MSVC `lib /OUT:` and is a separate token for GNU
  `ar -rs `. Object files (already individual tokens) and the `@response` file
  are appended as their own argv elements; argv exec also removes the shell
  command-length ceiling.
- `split_append` / `clean_shlex_token` are promoted to module scope so link and
  archive reuse the compile path's OS-native tokenization.

## Verification

Unix, OpenMP active:

```
$ fpm build --flag -fopenmp
[100%] Project compiled successfully.

$ fpm test --flag -fopenmp
TALLY=TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
TALLY=TTTTTTTTTTTT
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```

A fresh sample project compiles, archives (`libargvtest2.a`), links, and runs
through the new argv archive+link path.

## Note

`compile_c` / `compile_cpp` still shell out unserialized (pre-existing); the
"no concurrent shell fork" goal is not fully reached until they also exec via
argv. Tracked in krystophny/fpm-dev#4.
