### PR TITLE
feat: exec C/C++ compiles via argv, close the shell-fork gap

### DIFF
--- a/src/fpm_compile_commands.F90
+++ b/src/fpm_compile_commands.F90
@@ -284,39 +284,45 @@ module fpm_compile_commands
             return
         end if
 
-        ! Tokenize the input command into args(:)
-        if (target_os==OS_WINDOWS) then 
+        ! Get current working directory (no lexer state involved)
+        call get_current_directory(cwd, error)
+        if (allocated(error)) return
+
+        ! Tokenize the command and consume the deferred-length args(:) result
+        ! under the shared fpm_shlex_split lock. fortran-shlex is not reentrant,
+        ! and reading the result while another build thread re-enters the lexer
+        ! corrupts the tokens, so the split and readback stay in one region.
+        !$omp critical (fpm_shlex_split)
+        if (target_os==OS_WINDOWS) then
             args = ms_split(command, ucrt=.true., success=sh_success)
         else
             args = sh_split(command, join_spaced=.false., keep_quotes=.true., success=sh_success)
         end if
         n = size(args)
-        
-        if (n==0 .or. .not.sh_success) then 
+        if (n>0 .and. sh_success) then
+            ! Try to find the source file
+            allocate(character(len=0) :: source_file)
+            find_source_file: do i = 1, n-1
+                if (args(i) == "-c") then
+                    source_file = trim(args(i+1))
+                    exit find_source_file
+                end if
+            end do find_source_file
+
+            ! Fallback: use last argument if not found
+            if (len_trim(source_file)==0) source_file = trim(args(n))
+
+            ! Fill in the compile_command_t.
+            ! Use non-default initializer due to gcc 15 bug
+            cmd = compile_command_t(cwd, args, source_file)
+        end if
+        !$omp end critical (fpm_shlex_split)
+
+        if (n==0 .or. .not.sh_success) then
             call syntax_error(error, "compile_command_table_t failed tokenizing: <"//command//">")
             return
         end if
-        
-        ! Get current working directory
-        call get_current_directory(cwd, error)
-        if (allocated(error)) return
 
-        ! Try to find the source file
-        allocate(character(len=0) :: source_file)
-        find_source_file: do i = 1, n-1
-            if (args(i) == "-c") then
-                source_file = trim(args(i+1))
-                exit find_source_file
-            end if
-        end do find_source_file
-
-        ! Fallback: use last argument if not found
-        if (len_trim(source_file)==0) source_file = trim(args(n))
-
-        ! Fill in the compile_command_t. 
-        ! Use non-default initializer due to gcc 15 bug
-        cmd = compile_command_t(cwd, args, source_file)
-        
         ! Add it to the structure
         !$omp critical (command_update)
         call cct_register_object(self, cmd, error)

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1464,7 +1464,10 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
        if (tokenized) then
           call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
        else
+          ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+          !$omp critical (run_command)
           call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+          !$omp end critical (run_command)
        end if
        if (stat/=0) return
     endif
@@ -1559,8 +1562,9 @@ subroutine compile_c(self, input, output, args, log_file, stat, table, dry_run)
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
+    type(string_t), allocatable :: argv(:)
     type(error_t), allocatable :: error
-    logical :: mock
+    logical :: mock, tokenized
 
     ! Initialize intent(out) status so the mock path with no table returns
     ! a defined value.
@@ -1570,12 +1574,32 @@ subroutine compile_c(self, input, output, args, log_file, stat, table, dry_run)
     mock = .false.
     if (present(dry_run)) mock = dry_run
 
-    ! Set command
+    ! Set command (shell fallback string) and build the argv token list, exec'd
+    ! via argv spawn (fork-safe under OpenMP) rather than through a shell.
     command = self%cc // " -c " // input // " " // args // " -o " // output
+
+    tokenized = .true.
+    call split_append(argv, self%cc, .false., .false., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-c"))
+        call add_strings(argv, string_t(input))
+    end if
+    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
     ! Execute command
     if (.not.mock) then
-       call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       if (tokenized) then
+          call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       else
+          ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+          !$omp critical (run_command)
+          call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+          !$omp end critical (run_command)
+       end if
        if (stat/=0) return
     endif
 
@@ -1607,8 +1631,9 @@ subroutine compile_cpp(self, input, output, args, log_file, stat, table, dry_run
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
+    type(string_t), allocatable :: argv(:)
     type(error_t), allocatable :: error
-    logical :: mock
+    logical :: mock, tokenized
 
     ! Initialize intent(out) status so the mock path with no table returns
     ! a defined value.
@@ -1618,12 +1643,32 @@ subroutine compile_cpp(self, input, output, args, log_file, stat, table, dry_run
     mock = .false.
     if (present(dry_run)) mock = dry_run
 
-    ! Set command
+    ! Set command (shell fallback string) and build the argv token list, exec'd
+    ! via argv spawn (fork-safe under OpenMP) rather than through a shell.
     command = self%cxx // " -c " // input // " " // args // " -o " // output
+
+    tokenized = .true.
+    call split_append(argv, self%cxx, .false., .false., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-c"))
+        call add_strings(argv, string_t(input))
+    end if
+    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
     ! Execute command
     if (.not.mock) then
-       call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       if (tokenized) then
+          call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       else
+          ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+          !$omp critical (run_command)
+          call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+          !$omp end critical (run_command)
+       end if
        if (stat/=0) return
     endif
 

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1495,23 +1495,26 @@ subroutine split_append(argv, str, join_spaced, keep_quotes, ok)
 
     if (.not.ok) return
 
+    ! fortran-shlex is not reentrant, and the deferred-length parts(:) result it
+    ! returns must be consumed before another thread re-enters the lexer. Hold the
+    ! lock across both the split and the readback into argv.
     !$omp critical(fpm_shlex_split)
     if (os_is_unix()) then
         parts = sh_split(str, join_spaced=join_spaced, keep_quotes=keep_quotes, success=ok)
     else
         parts = ms_split(str, success=ok)
     end if
+    if (ok) then
+        do k = 1, size(parts)
+            if (len_trim(parts(k)) == 0) cycle
+            if (os_is_unix()) then
+                call add_strings(argv, string_t(clean_shlex_token(parts(k))))
+            else
+                call add_strings(argv, string_t(trim(parts(k))))
+            end if
+        end do
+    end if
     !$omp end critical(fpm_shlex_split)
-    if (.not.ok) return
-
-    do k = 1, size(parts)
-        if (len_trim(parts(k)) == 0) cycle
-        if (os_is_unix()) then
-            call add_strings(argv, string_t(clean_shlex_token(parts(k))))
-        else
-            call add_strings(argv, string_t(trim(parts(k))))
-        end if
-    end do
 end subroutine split_append
 
 function clean_shlex_token(token) result(clean)


### PR DESCRIPTION
Stacked on #10 (parallel link/archive). Base this PR on `feat/parallel-link-argv`.

## What

Close the last concurrent-shell-fork gap in the build loop.

#6 moved Fortran compiles to an argv spawn (`run_argv` → `posix_spawn` /
`CreateProcess`, fork-safe under OpenMP) and #10 did link/archive, but
`compile_c` and `compile_cpp` still shelled out via `run()`. Concurrent
`fork()` from OpenMP threads is the documented hazard (commit `bb891e3f`), so
any C/C++ build still had the race.

## Change

- `compile_c` (`self%cc`) and `compile_cpp` (`self%cxx`) build an argv token
  list and exec via `run_argv`, exactly as `compile_fortran` does.
- The rare shell fallbacks (tokenization failure) in `compile_c`,
  `compile_cpp`, and `compile_fortran` are wrapped in `critical(run_command)`,
  the same guard already used by link/archive and by `run_argv`'s own fallback.
- `command` (the shell-fallback string) is unchanged, so the
  `compile_commands.json` registration is identical.

After this, every `run()` of a shell command reachable from the OpenMP build
loop is either an argv spawn (fork-safe) or serialized under
`critical(run_command)`. No unguarded concurrent shell fork remains.

## Verification

```
$ fpm build --flag -fopenmp
[100%] Project compiled successfully.

$ fpm test --flag -fopenmp
TALLY=TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
TALLY=TTTTTTTTTTTT
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```

A mixed C + C++ + Fortran project builds, links, and runs correctly through the
new path:

```
cadd(2,3)=           5  cppmul(2,3)=           6
```

(`cadd.c` via `compile_c`, `cppmul.cpp` via `compile_cpp`, `main.f90` via
`compile_fortran`.)
