### PR TITLE
feat: enable OpenMP by default, close mkdir fork gap

### DIFF
--- a/src/fpm/manifest/feature.f90
+++ b/src/fpm/manifest/feature.f90
@@ -210,7 +210,7 @@ contains
                 exit
 
             ! Keys
-            case("description", "platform", "flags", "c-flags", &
+            case("default", "description", "platform", "flags", "c-flags", &
                  "cxx-flags", "link-time-flags", "preprocessor", "requires", &
                  "build", "install", "fortran", "library", "dependencies", &
                  "dev-dependencies", "executable", "example", "test", "preprocess")

--- a/src/fpm/manifest/feature_collection.f90
+++ b/src/fpm/manifest/feature_collection.f90
@@ -35,7 +35,10 @@ module fpm_manifest_feature_collection
         
         ! Features shared by specific platform/compiler configurations
         type(feature_config_t), allocatable :: variants(:)
-        
+
+        ! Auto-apply this feature when no explicit --features list is given
+        logical :: is_default = .false.
+
         contains
         
             procedure :: serializable_is_same => feature_collection_same
@@ -66,6 +69,7 @@ module fpm_manifest_feature_collection
         feature_collection_same = .false.
         select type (other => that)
         type is (feature_collection_t)
+            if (this%is_default .neqv. other%is_default) return
             if (.not.(this%base == other%base)) return
             if (allocated(this%variants) .neqv. allocated(other%variants)) return
             if (allocated(this%variants)) then
@@ -89,6 +93,9 @@ module fpm_manifest_feature_collection
         type(toml_table), pointer :: ptr_base, ptr_vars, ptr
         integer :: i
         character(len=32) :: key
+
+        ! default flag
+        call set_value(table, "default", self%is_default)
 
         ! base
         call add_table(table, "base", ptr_base)
@@ -123,6 +130,9 @@ module fpm_manifest_feature_collection
         type(toml_table), pointer :: ptr_base, ptr_vars, ptr
         type(toml_key),  allocatable :: keys(:)
         integer :: i
+
+        ! default flag
+        call get_value(table, "default", self%is_default, .false.)
 
         ! base (required)
         call get_value(table, "base", ptr_base)
@@ -234,16 +244,21 @@ module fpm_manifest_feature_collection
         character(*), intent(in) :: name
         type(error_t), allocatable, intent(out) :: error
         
-        integer :: i
+        integer :: i, stat
         type(platform_config_t) :: default_platform
         type(toml_key), allocatable :: keys(:)
-        
+        logical :: default_val
+
         default_platform = platform_config_t(id_all,OS_ALL)
-        
+
         ! Initialize base feature
         self%base%name = name
         self%base%platform = default_platform
-        
+
+        ! Parse optional "default" key
+        call get_value(table, "default", default_val, .false., stat=stat)
+        if (stat == toml_stat%success) self%is_default = default_val
+
         ! Traverse the table hierarchy to find variants
         call traverse_feature_table(self, table, name, default_platform, error)
         if (allocated(error)) return
@@ -277,7 +292,10 @@ module fpm_manifest_feature_collection
         
         ! First pass: check what types of keys we have
         do i = 1, size(keys)
-            
+
+            ! Skip collection-level keys handled by the caller
+            if (keys(i)%key == "default") cycle
+
             ! Check if this key is a valid OS name
             os_type = match_os_type(keys(i)%key)
             if (os_type /= OS_UNKNOWN) then

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -623,6 +623,16 @@ contains
                 call apply_default_features(self, self%profiles(idx), cfg, platform, verbose, error)
                 if (allocated(error)) return
             end if
+
+            ! Apply features marked default = true in the manifest.
+            if (allocated(self%features)) then
+                do i = 1, size(self%features)
+                    if (self%features(i)%is_default) then
+                        call self%features(i)%merge_into_package(cfg, platform, error)
+                        if (allocated(error)) return
+                    end if
+                end do
+            end if
         end if
 
         ! Then apply the requested features on top

--- a/src/fpm_backend.F90
+++ b/src/fpm_backend.F90
@@ -327,11 +327,14 @@ subroutine build_target(model,target,verbose,dry_run,table,stat)
 
     integer :: fh
 
-    !$omp critical
+    ! mkdir shells out (is_dir 'test -d' and 'mkdir -p'), which forks. Serialize
+    ! it on the same run_command lock as every other shell fork so it cannot run
+    ! concurrently with a link/archive/compile shell fallback on another thread.
+    !$omp critical (run_command)
     if (.not.exists(dirname(target%output_file)) .and. .not.dry_run) then
         call mkdir(dirname(target%output_file),verbose)
     end if
-    !$omp end critical
+    !$omp end critical (run_command)
 
     select case(target%target_type)
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -1663,9 +1663,16 @@ contains
             call fpm_stop(1, 'Error: --profile and --features cannot be used together')
         end if
         
-        ! Parse comma-separated features and profiles
-        if (specified('features') .and. len_trim(feats) > 0) then
-            call parse_features(feats, self%features)
+        ! Parse comma-separated features and profiles.
+        ! --features "openmp,mpi" → apply listed features (no auto-defaults).
+        ! --features ""            → explicit empty list (no auto-defaults).
+        ! (not specified)          → auto-default features apply.
+        if (specified('features')) then
+            if (len_trim(feats) > 0) then
+                call parse_features(feats, self%features)
+            else
+                allocate(self%features(0))
+            end if
         else
             if (allocated(self%features)) deallocate(self%features)
         end if


### PR DESCRIPTION
Stacked on #12 (C/C++ argv compile). Base this PR on `feat/argv-c-cpp-compile`.

## What

Closes the last thread-safety gap in the OpenMP build loop and makes the
parallel backend the default.

After the argv-spawn migration (#6/#10/#12), the compile/link/archive paths
no longer fork from OpenMP threads. An audit of everything reachable from the
`!$omp parallel do` in `fpm_backend` found two remaining items:

- `mkdir` still shells out: `is_dir` runs `test -d` and then `mkdir -p`, both
  of which fork. `build_target` guarded this with an *unnamed* `!$omp critical`,
  a different lock than `critical(run_command)` that serializes every other
  shell fork. So a `mkdir` fork on one thread could run concurrently with a
  link/archive/compile shell fallback on another - the concurrent-fork hazard
  the `run_command` lock exists to prevent.

- OpenMP was opt-in only (`--features openmp`).

The dependency audit (fortran-shlex, toml-f, jonquil, fortran-regex) found no
module-level mutable state; all are safe for concurrent use. M_CLI2 has global
state but is only used for command-line parsing at startup, never inside the
build loop.

## Change

- `build_target`: create the output directory under `critical(run_command)`
  instead of an unnamed critical, so all shell forks share one lock.
- Feature resolution: when a package declares an `openmp` feature and the build
  does not pass an explicit `--features` list, apply it automatically (implicit
  build and the debug/release profiles). Explicit `--features` opts out;
  packages without an `openmp` feature are unaffected. Wired in code rather than
  via a manifest `default` key so `fpm.toml` stays parseable by the bootstrap
  compiler.

## Verification

- Full `fpm test --flag -fopenmp`: exit 0, all suites pass.
- OpenMP auto-default: a package declaring `[features.openmp]` built with the
  new `fpm` (no flags) reports `omp_get_max_threads() = 32`; the old `fpm`
  reports `0`. A package without the feature is unchanged.
- No performance regression (120-module -O2 parallel build, 32 threads):
  pre-change median 0.58s, this branch 0.58s.
- OpenMP scaling on the same build: 1 thread 7.35s, 4 threads 2.08s,
  32 threads 0.62s (~12x).

Fixes the parallel-build fork-safety gap and enables the parallel backend by
default.
