### PR TITLE
Fix parallel command execution and CI bootstrap

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,19 +67,19 @@ jobs:
           # artifact and activates the openmp metapackage via the
           # `openmp` feature (see fpm.toml). Older gcc on linux segfault
           # with --static + libgomp at atexit teardown (see issue #962),
-          # so they omit `--features openmp` and remain serial.
+          # so they select an explicit empty feature set and remain serial.
           - os: ubuntu-latest
             toolchain: {compiler: gcc, version: 10}
-            release-flags: --flag '--static -g -fbacktrace -O3'
+            release-flags: --features '' --flag '--static -g -fbacktrace -O3'
           - os: ubuntu-latest
             toolchain: {compiler: gcc, version: 11}
-            release-flags: --flag '--static -g -fbacktrace -O3'
+            release-flags: --features '' --flag '--static -g -fbacktrace -O3'
           - os: ubuntu-latest
             toolchain: {compiler: gcc, version: 12}
-            release-flags: --flag '--static -g -fbacktrace -O3'
+            release-flags: --features '' --flag '--static -g -fbacktrace -O3'
           - os: ubuntu-latest
             toolchain: {compiler: gcc, version: 13}
-            release-flags: --flag '--static -g -fbacktrace -O3'
+            release-flags: --features '' --flag '--static -g -fbacktrace -O3'
           - os: ubuntu-latest
             toolchain: {compiler: gcc, version: 14}
             release-flags: --features openmp --flag '--static -g -fbacktrace -O3'
@@ -97,9 +97,22 @@ jobs:
     - name: Setup Fortran compiler
       uses: fortran-lang/setup-fortran@v1.9.0
       id: setup-fortran
+      continue-on-error: ${{ contains(matrix.os, 'macos') && matrix.toolchain.compiler == 'gcc' && matrix.toolchain.version == 11 }}
       with:
         compiler: ${{ matrix.toolchain.compiler }}
         version: ${{ matrix.toolchain.version }}
+
+    - name: Recover Homebrew GCC 11 after setup postinstall failure
+      if: contains(matrix.os, 'macos') && matrix.toolchain.compiler == 'gcc' && matrix.toolchain.version == 11
+      shell: bash
+      run: |
+        GCC_PREFIX=$(brew --prefix gcc@11)
+        GFORTRAN="$GCC_PREFIX/bin/gfortran-11"
+        test -x "$GFORTRAN"
+        "$GFORTRAN" --version
+        echo "$GCC_PREFIX/bin" >> "$GITHUB_PATH"
+        echo "FC=$GFORTRAN" >> "$GITHUB_ENV"
+        echo "FPM_FC=$GFORTRAN" >> "$GITHUB_ENV"
 
     # Phase 1: Bootstrap fpm with existing version
     - name: Install fpm
@@ -115,7 +128,6 @@ jobs:
       if: contains(matrix.os, 'macos')
       run: |
         which gfortran-${{ matrix.toolchain.version }}
-        which gfortran
         BREW_PREFIX=$(brew --prefix)
 
         # Query the actual library paths that fpm expects
@@ -203,6 +215,11 @@ jobs:
         mv $(which fpm) fpm-bootstrap${{ matrix.exe }}
         echo "BOOTSTRAP=$PWD/fpm-bootstrap" >> $GITHUB_ENV
 
+    - name: Use bootstrap-compatible manifest
+      shell: bash
+      run: |
+        git apply ci/bootstrap.patch
+
     - name: Build Fortran fpm (bootstrap)
       shell: bash
       run: |
@@ -232,6 +249,11 @@ jobs:
         ${{ env.BOOTSTRAP }} run --runner cp -- fpm-debug${{ matrix.exe }}
         rm -v ${{ env.BOOTSTRAP }}
         echo "FPM=$PWD/fpm-debug" >> $GITHUB_ENV
+
+    - name: Restore default feature manifest
+      shell: bash
+      run: |
+        git apply --reverse ci/bootstrap.patch
 
     - name: Get version (normal)
       if: github.event_name != 'release'

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -324,6 +324,11 @@ jobs:
         mv $(which fpm) fpm-bootstrap${{ matrix.exe }}
         echo "BOOTSTRAP=$PWD/fpm-bootstrap" >> $GITHUB_ENV
 
+    - name: Use bootstrap-compatible manifest
+      shell: bash
+      run: |
+        git apply ci/bootstrap.patch
+
     - name: (macOS/Ubuntu) Use gcc/g++ instead of Clang for C/C++ / ifx to build fpm
       if: contains(matrix.os,'macOS') || contains(matrix.os,'ubuntu')
       shell: bash
@@ -362,6 +367,11 @@ jobs:
         ${{ env.BOOTSTRAP }} run --runner cp -- fpm-debug${{ matrix.exe }}
         rm -v ${{ env.BOOTSTRAP }}
         echo "FPM=$PWD/fpm-debug" >> $GITHUB_ENV
+
+    - name: Restore default feature manifest
+      shell: bash
+      run: |
+        git apply --reverse ci/bootstrap.patch
 
     - name: Get version (normal)
       if: github.event_name != 'release'

--- a/ci/bootstrap.patch
+++ b/ci/bootstrap.patch
@@ -1,0 +1,13 @@
+diff --git a/fpm.toml b/fpm.toml
+--- a/fpm.toml
++++ b/fpm.toml
+@@ -23,8 +23,5 @@ jonquil.rev = "4fbd4cf34d577c0fd25e32667ee9e41bf231ece8"
+ fortran-shlex.git = "https://github.com/perazz/fortran-shlex"
+ fortran-shlex.tag = "2.0.1"
+-
++
+-[features.openmp]
+-default = true
+-
+ [features.openmp.dependencies]
+ openmp = "*"

--- a/ci/single-file.patch
+++ b/ci/single-file.patch
@@ -1,11 +1,18 @@
 diff --git a/fpm.toml b/fpm.toml
-index 51faa0e9..273e8e0e 100644
 --- a/fpm.toml
 +++ b/fpm.toml
-@@ -17,23 +17,5 @@ M_CLI2.rev = "7264878cdb1baff7323cc48596d829ccfe7751b8"
- jonquil.git = "https://github.com/toml-f/jonquil"
- jonquil.rev = "05d30818bb12fb877226ce284b9a3a41b971a889"
- 
+@@ -23,28 +23,7 @@ jonquil.rev = "4fbd4cf34d577c0fd25e32667ee9e41bf231ece8"
+ fortran-shlex.git = "https://github.com/perazz/fortran-shlex"
+ fortran-shlex.tag = "2.0.1"
+-
++
+-[features.openmp]
+-default = true
+-
+ [features.openmp.dependencies]
+ openmp = "*"
+-
++
 -[[test]]
 -name = "cli-test"
 -source-dir = "test/cli_test"
@@ -25,6 +32,5 @@ index 51faa0e9..273e8e0e 100644
 -name = "help-test"
 -source-dir = "test/help_test"
 -main = "help_test.f90"
--
 +[build]
 +auto-tests = false

--- a/example_packages/metapackage_stdlib/app/main.f90
+++ b/example_packages/metapackage_stdlib/app/main.f90
@@ -7,6 +7,7 @@ program test_stdlib_metapackage
     use stdlib_math
     implicit none
 
+    integer, parameter :: available_kinds(3) = [int32, int64, sp]
     real(dp), allocatable :: indices(:)
 
     indices = linspace(1.0_dp,5.0_dp,5)

--- a/example_packages/tree_shake/src/extra_m.f90
+++ b/example_packages/tree_shake/src/extra_m.f90
@@ -6,7 +6,7 @@ module extra_m
     implicit none
     private
 
-    integer, parameter :: m = 0
+    integer, parameter :: m = 0 * len(FAREWELL_STR)
 end
 
 function external_function() result(i)

--- a/src/filesystem_utilities.c
+++ b/src/filesystem_utilities.c
@@ -328,11 +328,8 @@ int c_run_argv(const char *joined, int argc, const char *redirect)
 
 /*
  * Spawn a child process without waiting.  Returns the PID (>0) on
- * success, or a negative errno on failure.
- *
- * Must be called from a single thread — glibc's posix_spawn uses
- * clone(CLONE_VM|CLONE_VFORK) which shares the parent address space,
- * so concurrent spawns corrupt heap state.
+ * success, or a negative errno on failure.  Callers serialize spawning
+ * because allocator corruption was observed during concurrent spawns.
  */
 #ifndef _WIN32
 int c_spawn_argv(const char *joined, int argc, const char *redirect)
@@ -394,6 +391,20 @@ int c_wait_pid(int raw_pid)
     if (ws < 0) return -1;
     if (WIFEXITED(wait_status)) return WEXITSTATUS(wait_status);
     if (WIFSIGNALED(wait_status)) return 128 + WTERMSIG(wait_status);
+    return -1;
+}
+#else
+int c_spawn_argv(const char *joined, int argc, const char *redirect)
+{
+    (void)joined;
+    (void)argc;
+    (void)redirect;
+    return -1;
+}
+
+int c_wait_pid(int raw_pid)
+{
+    (void)raw_pid;
     return -1;
 }
 #endif

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -1,9 +1,9 @@
 module fpm
-use fpm_strings, only: string_t, operator(.in.), glob, join, string_cat, &
+use fpm_strings, only: string_t, operator(.in.), join, string_cat, &
                       lower, str_ends_with, is_fortran_name, str_begins_with_str, &
                       is_valid_module_name, len_trim
 use fpm_backend, only: build_package
-use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
+use fpm_command_line, only: fpm_build_settings, &
                       fpm_run_settings, fpm_install_settings, fpm_test_settings, &
                       fpm_clean_settings
 use fpm_dependency, only : new_dependency_tree
@@ -29,8 +29,7 @@ use fpm_toml, only: name_is_json
 use, intrinsic :: iso_fortran_env, only : stdin => input_unit, &
                                         & stdout => output_unit, &
                                         & stderr => error_unit
-use iso_c_binding, only: c_char, c_ptr, c_int, c_null_char, c_associated, c_f_pointer
-use fpm_environment, only: os_is_unix, get_os_type, OS_WINDOWS, OS_MACOS, get_env, set_env, delete_env
+use fpm_environment, only: os_is_unix, get_os_type, OS_WINDOWS, OS_MACOS, get_env, set_env
 use fpm_settings, only: fpm_global_settings, get_global_settings
 
 implicit none
@@ -440,7 +439,7 @@ subroutine check_modules_for_duplicates(model, duplicates_found)
       do l=1,size(model%packages(k)%sources)
         if (allocated(model%packages(k)%sources(l)%modules_provided)) then
           do m=1,size(model%packages(k)%sources(l)%modules_provided)
-            if (model%packages(k)%sources(l)%modules_provided(m)%s.in.modules(:modi-1)) then
+            if (model%packages(k)%sources(l)%modules_provided(m)%s .in. modules(:modi-1)) then
               write(stderr, *) "Warning: Module ",model%packages(k)%sources(l)%modules_provided(m)%s, &
                 " in ",model%packages(k)%sources(l)%file_name," is a duplicate"
               duplicates_found = .true.

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -8,7 +8,7 @@ module fpm_cmd_install
   use fpm_installer, only : installer_t, new_installer
   use fpm_manifest, only : package_config_t, get_package_data
   use fpm_model, only : fpm_model_t, FPM_SCOPE_APP, FPM_SCOPE_TEST
-  use fpm_targets, only: targets_from_sources, build_target_t, &
+  use fpm_targets, only: targets_from_sources, &
                          build_target_ptr, FPM_TARGET_EXECUTABLE, &
                          filter_library_targets, filter_executable_targets, filter_modules
   use fpm_strings, only : string_t, resize

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -8,7 +8,7 @@ module fpm_cmd_publish
   use fpm_model, only: fpm_model_t
   use fpm_error, only: error_t, fpm_stop
   use fpm_versioning, only: version_t
-  use fpm_filesystem, only: exists, join_path, get_temp_filename, delete_file
+  use fpm_filesystem, only: exists, get_temp_filename, delete_file
   use fpm_git, only: git_archive
   use fpm_downloader, only: downloader_t
   use fpm_strings, only: string_t

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -64,8 +64,8 @@ module fpm_dependency
   use fpm_manifest, only: package_config_t, dependency_config_t, get_package_data, get_package_dependencies
   use fpm_manifest_dependency, only: manifest_has_changed, dependency_destroy
   use fpm_manifest_preprocess, only: operator(==)
-  use fpm_strings, only: string_t, operator(.in.), operator(==), str
-  use tomlf, only: toml_table, toml_key, toml_error, toml_load, toml_stat, toml_array, len, add_array
+  use fpm_strings, only: string_t, operator(==), str
+  use tomlf, only: toml_table, toml_key, toml_error, toml_load, toml_array, len
   use fpm_toml, only: toml_serialize, get_value, set_value, add_table, set_string, get_list, set_list
   use fpm_versioning, only: version_t, new_version
   use fpm_settings, only: fpm_global_settings, get_global_settings, official_registry_base_url

--- a/src/fpm/manifest.f90
+++ b/src/fpm/manifest.f90
@@ -18,7 +18,6 @@ module fpm_manifest
     use fpm_toml, only : read_package_file
     use fpm_manifest_test, only : test_config_t
     use fpm_filesystem, only: join_path, exists, dirname, is_dir
-    use fpm_environment, only: os_is_unix
     use fpm_strings, only: string_t
     implicit none
     private

--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -37,7 +37,7 @@ module fpm_manifest_dependency
         & set_value, set_string, get_list, set_list
     use fpm_filesystem, only: windows_path, join_path
     use fpm_environment, only: get_os_type, OS_WINDOWS
-    use fpm_manifest_metapackages, only: metapackage_config_t, is_meta_package, new_meta_config, &
+    use fpm_manifest_metapackages, only: metapackage_config_t, new_meta_config, &
             metapackage_request_t, new_meta_request
     use fpm_versioning, only: version_t, new_version
     use fpm_strings, only: string_t

--- a/src/fpm/manifest/feature.f90
+++ b/src/fpm/manifest/feature.f90
@@ -35,15 +35,15 @@ module fpm_manifest_feature
     use fpm_manifest_install, only: install_config_t, new_install_config
     use fpm_manifest_test, only: test_config_t, new_test
     use fpm_manifest_preprocess, only: preprocess_config_t, new_preprocessors
-    use fpm_manifest_metapackages, only: metapackage_config_t, new_meta_config
+    use fpm_manifest_metapackages, only: metapackage_config_t
     use fpm_manifest_platform, only: platform_config_t
     use fpm_error, only: error_t, fatal_error, syntax_error
-    use fpm_environment, only: OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, OS_CYGWIN, OS_SOLARIS, &
+    use fpm_environment, only: &
                              OS_FREEBSD, OS_OPENBSD, OS_ALL, OS_NAME, match_os_type
-    use fpm_compiler, only: compiler_enum, compiler_id_name, match_compiler_type, id_all
-    use fpm_strings, only: string_t, lower, operator(==)
+    use fpm_compiler, only: id_all
+    use fpm_strings, only: string_t, operator(==)
     use tomlf, only: toml_table, toml_array, toml_key, toml_stat
-    use fpm_toml, only: get_value, len, serializable_t, set_value, set_string, set_list, add_table, &
+    use fpm_toml, only: get_value, len, serializable_t, set_string, set_list, add_table, &
                         get_list
     implicit none
     private

--- a/src/fpm/manifest/feature_collection.f90
+++ b/src/fpm/manifest/feature_collection.f90
@@ -1,6 +1,6 @@
 
 module fpm_manifest_feature_collection
-    use fpm_manifest_feature, only: feature_config_t, new_feature, init_feature_components
+    use fpm_manifest_feature, only: feature_config_t, init_feature_components
     use fpm_manifest_platform, only: platform_config_t, is_platform_key    
     use fpm_manifest_dependency, only: dependency_config_t
     use fpm_manifest_example, only: example_config_t
@@ -8,17 +8,17 @@ module fpm_manifest_feature_collection
     use fpm_manifest_metapackages, only: metapackage_config_t, metapackage_request_t
     use fpm_manifest_test, only: test_config_t
     use fpm_manifest_preprocess, only: preprocess_config_t
-    use fpm_error, only: error_t, fatal_error, syntax_error
-    use fpm_environment, only: OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, OS_CYGWIN, OS_SOLARIS, &
+    use fpm_error, only: error_t, fatal_error
+    use fpm_environment, only: OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, &
                              OS_FREEBSD, OS_OPENBSD, OS_ALL, match_os_type, OS_NAME
     use fpm_compiler, only: compiler_enum, compiler_id_name, match_compiler_type, &
                           id_unknown, id_gcc, id_f95, id_caf, &
                           id_intel_classic_nix, id_intel_classic_mac, id_intel_classic_windows, &
                           id_intel_llvm_nix, id_intel_llvm_windows, id_intel_llvm_unknown, &
                           id_pgi, id_nvhpc, id_nag, id_flang, id_lahey, id_lfortran, id_all
-    use fpm_strings, only: string_t, lower, operator(==), split, str
-    use tomlf, only: toml_table, toml_array, toml_key, toml_stat
-    use fpm_toml, only: get_value, len, serializable_t, set_value, set_string, set_list, add_table, &
+    use fpm_strings, only: string_t, operator(==), str
+    use tomlf, only: toml_table, toml_key, toml_stat
+    use fpm_toml, only: get_value, len, serializable_t, set_value, add_table, &
                         get_list
     implicit none
     private

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -34,14 +34,12 @@
 !>[extra]
 !>```
 module fpm_manifest_package
-    use fpm_manifest_build, only: build_config_t, new_build_config
     use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
     use fpm_manifest_profile, only : profile_config_t, new_profiles, add_default_profiles
     use fpm_manifest_example, only : example_config_t, new_example
     use fpm_manifest_executable, only : executable_config_t, new_executable
     use fpm_manifest_fortran, only : fortran_config_t, new_fortran_config
     use fpm_manifest_library, only : library_config_t, new_library
-    use fpm_manifest_install, only: install_config_t, new_install_config
     use fpm_manifest_test, only : test_config_t, new_test
     use fpm_manifest_preprocess, only : preprocess_config_t, new_preprocessors
     use fpm_manifest_feature, only: feature_config_t, init_feature_components
@@ -856,10 +854,8 @@ contains
 
     !> Print feature collection information in verbose mode
     subroutine print_feature_collection(collection, platform)
-        use, intrinsic :: iso_fortran_env, only: stdout => output_unit
         use fpm_compiler, only: compiler_name
         use fpm_environment, only: os_name
-        use fpm_strings, only: string_cat
         type(feature_collection_t), intent(in) :: collection
         type(platform_config_t), intent(in) :: platform
 

--- a/src/fpm/manifest/profiles.f90
+++ b/src/fpm/manifest/profiles.f90
@@ -13,10 +13,10 @@
 !>features = ["optimized", "strip-symbols"]
 !>```
 module fpm_manifest_profile
-    use fpm_error, only: error_t, fatal_error, syntax_error
+    use fpm_error, only: error_t, fatal_error
     use fpm_strings, only: string_t, operator(==)
     use tomlf, only: toml_table, toml_array, toml_key, toml_stat, len
-    use fpm_toml, only: get_value, serializable_t, set_string, set_list, get_list, add_table
+    use fpm_toml, only: get_value, serializable_t, set_string, set_list, get_list
     
     implicit none
     private

--- a/src/fpm/toml.f90
+++ b/src/fpm/toml.f90
@@ -18,8 +18,7 @@ module fpm_toml
     use tomlf, only: toml_table, toml_array, toml_key, toml_stat, get_value, &
         & set_value, toml_parse, toml_error, new_table, add_table, add_array, &
         & toml_serialize, len, toml_load, toml_value
-    use tomlf_de_parser, only: parse
-    use jonquil, only: json_serialize, json_error, json_value, json_object, json_load, &
+    use jonquil, only: json_serialize, json_load, &
                        cast_to_object
     use iso_fortran_env, only: int64
     implicit none

--- a/src/fpm_backend.F90
+++ b/src/fpm_backend.F90
@@ -81,6 +81,7 @@ subroutine build_package(targets,model,verbose,dry_run)
     allocate(build_dirs(0))
     do i = 1, size(targets)
        associate(target => targets(i)%ptr)
+          if (len(target%output_dir) == 0) cycle
           if (target%output_dir .in. build_dirs) cycle
           temp%s = target%output_dir
           build_dirs = [build_dirs, temp]

--- a/src/fpm_backend_output.f90
+++ b/src/fpm_backend_output.f90
@@ -15,7 +15,7 @@ use fpm_error, only: error_t
 use fpm_filesystem, only: basename,join_path
 use fpm_targets, only: build_target_ptr
 use fpm_backend_console, only: console_t, LINE_RESET, COLOR_RED, COLOR_GREEN, COLOR_YELLOW, COLOR_RESET
-use fpm_compile_commands, only: compile_command_t, compile_command_table_t
+use fpm_compile_commands, only: compile_command_table_t
 implicit none
 
 private

--- a/src/fpm_compile_commands.F90
+++ b/src/fpm_compile_commands.F90
@@ -43,8 +43,10 @@ module fpm_compile_commands
         procedure :: write                => cct_write
         
         procedure, private :: cct_register
+        procedure, private :: cct_register_argv
         procedure, private :: cct_register_object
         generic   :: register             => cct_register, &
+                                             cct_register_argv, &
                                              cct_register_object
         
         !> Serialization interface
@@ -329,6 +331,42 @@ module fpm_compile_commands
         !$omp end critical (command_update)
 
     end subroutine cct_register
+
+    subroutine cct_register_argv(self, arguments, source_file, error)
+
+        class(compile_command_table_t), intent(inout) :: self
+        type(string_t), intent(in) :: arguments(:)
+        character(len=*), intent(in) :: source_file
+        type(error_t), allocatable, intent(out) :: error
+
+        type(compile_command_t) :: cmd
+        character(len=:), allocatable :: cwd
+        integer :: i
+
+        if (size(arguments) == 0) then
+            call syntax_error(error, "compile_command_table_t trying to register empty arguments")
+            return
+        end if
+        if (len_trim(source_file) == 0) then
+            call syntax_error(error, "compile_command_table_t trying to register an empty source file")
+            return
+        end if
+
+        call get_current_directory(cwd, error)
+        if (allocated(error)) return
+
+        cmd%directory = string_t(trim(cwd))
+        allocate(cmd%arguments(size(arguments)))
+        do i = 1, size(arguments)
+            cmd%arguments(i) = arguments(i)
+        end do
+        cmd%file = string_t(source_file)
+
+        !$omp critical (command_update)
+        call cct_register_object(self, cmd, error)
+        !$omp end critical (command_update)
+
+    end subroutine cct_register_argv
     
     pure subroutine cct_register_object(self, command, error)
     

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1407,6 +1407,28 @@ subroutine new_archiver(self, ar, echo, verbose)
     self%verbose = verbose
 end subroutine new_archiver
 
+subroutine prepare_compile_argv(argv, executable, input, args, output, tokenized)
+    type(string_t), allocatable, intent(out) :: argv(:)
+    character(len=*), intent(in) :: executable, input, args, output
+    logical, intent(out) :: tokenized
+
+    !$omp critical(fpm_compile_argv)
+    tokenized = .true.
+    call split_append(argv, executable, .false., .false., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-c"))
+        call add_strings(argv, string_t(input))
+    end if
+    if (tokenized .and. len_trim(args) > 0) then
+        call split_append(argv, args, .true., .true., tokenized)
+    end if
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
+    !$omp end critical(fpm_compile_argv)
+end subroutine prepare_compile_argv
+
 
 !> Compile a Fortran object
 subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry_run)
@@ -1445,19 +1467,7 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
     ! otherwise) so quoting and backslash paths survive on both platforms.
     command = self%fc // " -c " // input // " " // args // " -o " // output
 
-    tokenized = .true.
-    call split_append(argv, self%fc, .false., .false., tokenized)
-    if (tokenized) then
-        call add_strings(argv, string_t("-c"))
-        call add_strings(argv, string_t(input))
-    end if
-    if (tokenized .and. len_trim(args) > 0) then
-        call split_append(argv, args, .true., .true., tokenized)
-    end if
-    if (tokenized) then
-        call add_strings(argv, string_t("-o"))
-        call add_strings(argv, string_t(output))
-    end if
+    call prepare_compile_argv(argv, self%fc, input, args, output, tokenized)
 
     ! Execute command
     if (.not.mock) then
@@ -1474,7 +1484,11 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
 
     ! Optionally register compile command
     if (present(table)) then
-        call table%register(command, get_os_type(), error)
+        if (tokenized) then
+            call table%register(argv, input, error)
+        else
+            call table%register(command, get_os_type(), error)
+        end if
         stat = merge(-1,0,allocated(error))
     endif
 
@@ -1581,17 +1595,7 @@ subroutine compile_c(self, input, output, args, log_file, stat, table, dry_run)
     ! via argv spawn (fork-safe under OpenMP) rather than through a shell.
     command = self%cc // " -c " // input // " " // args // " -o " // output
 
-    tokenized = .true.
-    call split_append(argv, self%cc, .false., .false., tokenized)
-    if (tokenized) then
-        call add_strings(argv, string_t("-c"))
-        call add_strings(argv, string_t(input))
-    end if
-    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
-    if (tokenized) then
-        call add_strings(argv, string_t("-o"))
-        call add_strings(argv, string_t(output))
-    end if
+    call prepare_compile_argv(argv, self%cc, input, args, output, tokenized)
 
     ! Execute command
     if (.not.mock) then
@@ -1608,7 +1612,11 @@ subroutine compile_c(self, input, output, args, log_file, stat, table, dry_run)
 
     ! Optionally register compile command
     if (present(table)) then
-        call table%register(command, get_os_type(), error)
+        if (tokenized) then
+            call table%register(argv, input, error)
+        else
+            call table%register(command, get_os_type(), error)
+        end if
         stat = merge(-1,0,allocated(error))
     endif
 
@@ -1650,17 +1658,7 @@ subroutine compile_cpp(self, input, output, args, log_file, stat, table, dry_run
     ! via argv spawn (fork-safe under OpenMP) rather than through a shell.
     command = self%cxx // " -c " // input // " " // args // " -o " // output
 
-    tokenized = .true.
-    call split_append(argv, self%cxx, .false., .false., tokenized)
-    if (tokenized) then
-        call add_strings(argv, string_t("-c"))
-        call add_strings(argv, string_t(input))
-    end if
-    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
-    if (tokenized) then
-        call add_strings(argv, string_t("-o"))
-        call add_strings(argv, string_t(output))
-    end if
+    call prepare_compile_argv(argv, self%cxx, input, args, output, tokenized)
 
     ! Execute command
     if (.not.mock) then
@@ -1677,7 +1675,11 @@ subroutine compile_cpp(self, input, output, args, log_file, stat, table, dry_run
 
     ! Optionally register compile command
     if (present(table)) then
-        call table%register(command, get_os_type(), error)
+        if (tokenized) then
+            call table%register(argv, input, error)
+        else
+            call table%register(command, get_os_type(), error)
+        end if
         stat = merge(-1,0,allocated(error))
     endif
 

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -3,7 +3,6 @@
 module fpm_filesystem
     use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, stdout=>output_unit, &
         stderr=>error_unit, int64
-    use,intrinsic :: iso_c_binding, only: c_new_line
     use fpm_environment, only: get_os_type, &
                                OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, &
                                OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD
@@ -17,9 +16,12 @@ module fpm_filesystem
     public :: basename, canon_path, dirname, is_dir, join_path, number_of_rows, list_files, get_local_prefix, &
             mkdir, exists, get_temp_filename, windows_path, unix_path, getline, delete_file, fileopen, fileclose, &
             filewrite, warnwrite, parent_dir, is_hidden_file, read_lines, read_lines_expanded, &
-            read_text_file, which, run, run_argv, spawn_argv, wait_pid, &
+            read_text_file, which, run, run_argv, &
             os_delete_dir, is_absolute_path, get_home, execute_and_read_output, get_dos_path, &
             get_file_mtime
+#ifndef FPM_BOOTSTRAP
+    public :: spawn_argv, wait_pid
+#endif
 
 #ifndef FPM_BOOTSTRAP
     interface
@@ -1157,6 +1159,21 @@ subroutine run_argv(args,echo,exitstat,verbose,redirect)
     if (size(args) < 1) then
         stat = 0
 #ifndef FPM_BOOTSTRAP
+    else if (os_is_unix()) then
+        ! Allocator corruption was observed while parallel builds spawned concurrently.
+        ! Serialize that interval and wait outside the lock so that
+        ! compilation remains concurrent.
+        block
+            integer :: pid
+            !$omp critical (run_command)
+            pid = spawn_argv(args, redirect_file)
+            !$omp end critical (run_command)
+            if (pid > 0) then
+                stat = wait_pid(pid)
+            else
+                stat = -1
+            end if
+        end block
     else
         joined = ""
         do i = 1, size(args)
@@ -1206,6 +1223,7 @@ subroutine run_argv(args,echo,exitstat,verbose,redirect)
 
 end subroutine run_argv
 
+#ifndef FPM_BOOTSTRAP
 !> Spawn a child process without waiting.  Returns the PID (>0), or
 !> a negative value on failure.  Must be called from a single thread.
 function spawn_argv(args, redirect) result(pid)
@@ -1231,6 +1249,7 @@ function wait_pid(pid) result(stat)
     integer :: stat
     stat = c_wait_pid(int(pid, c_int))
 end function wait_pid
+#endif
 
 !> Delete directory using system OS remove directory commands
 subroutine os_delete_dir(is_unix, dir, echo)

--- a/src/fpm_meta.f90
+++ b/src/fpm_meta.f90
@@ -25,7 +25,7 @@ module fpm_meta
     use fpm_error, only: error_t, syntax_error, fatal_error
     use fpm_filesystem, only: join_path
 
-    use fpm_meta_base, only: metapackage_t, destroy
+    use fpm_meta_base, only: metapackage_t
     use fpm_meta_openmp, only: init_openmp
     use fpm_meta_stdlib, only: init_stdlib
     use fpm_meta_minpack, only: init_minpack
@@ -35,8 +35,6 @@ module fpm_meta
     use fpm_meta_blas, only: init_blas
     use fpm_manifest_metapackages, only: metapackage_request_t, metapackage_config_t
 
-    use shlex_module, only: shlex_split => split
-    use regex_module, only: regex
     use iso_fortran_env, only: stdout => output_unit
 
     implicit none

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -40,11 +40,11 @@ use fpm_compiler, only: compiler_t, archiver_t, debug
 use fpm_dependency, only: dependency_tree_t
 use fpm_versioning, only: version_t, new_version
 use fpm_strings, only: string_t, str, len_trim, upper, operator(==)
-use tomlf, only: toml_table, toml_stat
+use tomlf, only: toml_table
 use fpm_toml, only: serializable_t, set_value, set_list, get_value, &
                     & get_list, add_table, toml_key, add_array, set_string
 use fpm_error, only: error_t, fatal_error
-use fpm_environment, only: OS_WINDOWS,OS_MACOS, get_os_type, OS_UNKNOWN, OS_LINUX, OS_CYGWIN, &
+use fpm_environment, only: &
                               OS_SOLARIS, OS_FREEBSD, OS_OPENBSD, OS_ALL, validate_os_name, OS_NAME, &
                               match_os_type
 use fpm_manifest_preprocess, only: preprocess_config_t

--- a/src/fpm_pkg_config.f90
+++ b/src/fpm_pkg_config.f90
@@ -4,7 +4,7 @@
 !>
 module fpm_pkg_config
 
-use fpm_strings, only: string_t,str_begins_with_str,len_trim,remove_newline_characters, &
+use fpm_strings, only: string_t, len_trim, remove_newline_characters, &
     split
 use fpm_error, only: error_t, fatal_error, fpm_stop
 use fpm_filesystem, only: get_temp_filename,getline

--- a/src/fpm_runner.F90
+++ b/src/fpm_runner.F90
@@ -1,9 +1,11 @@
 module fpm_runner
 use fpm_command_line, only: fpm_run_settings
 use fpm_environment, only: get_env, get_os_type, os_is_unix, OS_MACOS
-use fpm_filesystem, only: delete_file, exists, get_temp_filename, getline, run, run_argv, &
-                         spawn_argv, wait_pid
-use fpm_strings, only: add_strings, string_cat, string_t
+use fpm_filesystem, only: delete_file, exists, get_temp_filename, getline, run, run_argv
+#ifndef FPM_BOOTSTRAP
+use fpm_filesystem, only: spawn_argv, wait_pid
+#endif
+use fpm_strings, only: add_strings, string_t
 use shlex_module, only: ms_split, sh_split => split
 implicit none
 private
@@ -46,7 +48,8 @@ subroutine run_executables(executables, settings, parallel, stat)
         end do
     end if
 
-    if (parallel) then
+#ifndef FPM_BOOTSTRAP
+    if (parallel .and. os_is_unix()) then
         block
             integer, allocatable :: pids(:)
             allocate(pids(size(commands)))
@@ -61,6 +64,16 @@ subroutine run_executables(executables, settings, parallel, stat)
                 end if
             end do
         end block
+    else if (parallel) then
+#else
+    if (parallel) then
+#endif
+        !$omp parallel do default(shared) schedule(dynamic,1)
+        do i = 1, size(commands)
+            call run_argv(commands(i)%argv, echo=.false., verbose=.false., &
+                          redirect=commands(i)%log_file%s, exitstat=stat(i))
+        end do
+        !$omp end parallel do
     else
         do i = 1, size(commands)
             call run_argv(commands(i)%argv, echo=.false., verbose=.false., &

--- a/src/fpm_settings.f90
+++ b/src/fpm_settings.f90
@@ -5,7 +5,7 @@ module fpm_settings
   use fpm_error, only: error_t, fatal_error
   use tomlf, only: toml_table, toml_error, toml_stat, toml_load
   use fpm_toml, only: get_value, check_keys
-  use fpm_os, only: get_current_directory, change_directory, get_absolute_path, convert_to_absolute_path
+  use fpm_os, only: get_absolute_path, convert_to_absolute_path
 
   implicit none
   private

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -16,7 +16,7 @@
 !>
 module fpm_source_parsing
 use fpm_error, only: error_t, file_parse_error, fatal_error, file_not_found_error
-use fpm_strings, only: string_t, string_cat, len_trim, split, lower, str_ends_with, fnv_1a, &
+use fpm_strings, only: string_t, len_trim, split, lower, str_ends_with, fnv_1a, &
     is_fortran_name, operator(.in.), operator(==)
 use fpm_model, only: srcfile_t, &
                     FPM_UNIT_UNKNOWN, FPM_UNIT_PROGRAM, FPM_UNIT_MODULE, &

--- a/src/fpm_strings.f90
+++ b/src/fpm_strings.f90
@@ -38,7 +38,7 @@ use iso_fortran_env, only: int64
 use,intrinsic :: iso_fortran_env, only : stdin=>input_unit,   &
                                        & stdout=>output_unit, &
                                        & stderr=>error_unit
-use iso_c_binding, only: c_char, c_ptr, c_int, c_null_char, c_associated, c_f_pointer, c_size_t
+use iso_c_binding, only: c_char, c_ptr, c_null_char, c_f_pointer, c_size_t
 implicit none
 
 private

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -24,11 +24,11 @@
 !> Describes the type of build target — determines backend build rules
 !>
 module fpm_targets
-use iso_fortran_env, only: int64, stdout=>output_unit
+use iso_fortran_env, only: int64
 use fpm_error, only: error_t, fatal_error, fpm_stop
 use fpm_model
 use fpm_compiler, only : compiler_t
-use fpm_environment, only: get_os_type, OS_WINDOWS, OS_MACOS, library_filename
+use fpm_environment, only: get_os_type, OS_MACOS, library_filename
 use fpm_filesystem, only: dirname, join_path, canon_path
 use fpm_strings, only: string_t, operator(.in.), string_cat, fnv_1a, resize, lower, str_ends_with, &
     add_strings
@@ -36,7 +36,7 @@ use fpm_compiler, only: get_macros, is_cxx_gnu_based
 use fpm_sources, only: get_exe_name_with_suffix
 use fpm_manifest_library, only: library_config_t
 use fpm_manifest_preprocess, only: preprocess_config_t
-use fpm_versioning, only: version_t, new_version
+use fpm_versioning, only: version_t
 implicit none
 
 private

--- a/src/metapackage/fpm_meta_base.f90
+++ b/src/metapackage/fpm_meta_base.f90
@@ -6,7 +6,7 @@ module fpm_meta_base
     use fpm_manifest_dependency, only: dependency_config_t
     use fpm_manifest_preprocess, only: preprocess_config_t
     use fpm_manifest, only: package_config_t
-    use fpm_strings, only: string_t, len_trim, split, join
+    use fpm_strings, only: string_t, len_trim
     use fpm_compiler, only: append_clean_flags, append_clean_flags_array
 
     implicit none

--- a/src/metapackage/fpm_meta_util.f90
+++ b/src/metapackage/fpm_meta_util.f90
@@ -1,5 +1,5 @@
 module fpm_meta_util
-    use fpm_meta_base, only: metapackage_t, destroy
+    use fpm_meta_base, only: metapackage_t
     use fpm_filesystem, only: join_path
     use fpm_strings, only: split, string_t, str_begins_with_str, add_strings
     use fpm_error, only: error_t

--- a/test/cli_test/cli_test.f90
+++ b/test/cli_test/cli_test.f90
@@ -250,10 +250,6 @@ use fpm_command_line, only: &
         fpm_install_settings, &
         get_command_line_settings, &
         fpm_publish_settings
-use fpm, only: cmd_run, cmd_clean
-use fpm_cmd_install, only: cmd_install
-use fpm_cmd_new, only: cmd_new
-use fpm_cmd_publish, only: cmd_publish
 class(fpm_cmd_settings), allocatable :: cmd_settings
 ! duplicates the calls as seen in the main program for fpm
 call get_command_line_settings(cmd_settings)

--- a/test/fpm_test/test_backend.f90
+++ b/test/fpm_test/test_backend.f90
@@ -2,8 +2,8 @@
 module test_backend
     use testsuite, only : new_unittest, unittest_t, error_t, test_failed
     use test_module_dependencies, only: operator(.in.)
-    use fpm_filesystem, only: exists, mkdir, get_temp_filename, delete_file
-    use fpm_targets, only: build_target_t, build_target_ptr, &
+    use fpm_filesystem, only: exists, get_temp_filename, delete_file
+    use fpm_targets, only: build_target_ptr, &
                             FPM_TARGET_OBJECT, FPM_TARGET_ARCHIVE, FPM_TARGET_SHARED, &
                            add_target, add_dependency
     use fpm_backend, only: sort_target, schedule_targets, object_can_skip, deps_fingerprint
@@ -241,7 +241,7 @@ contains
         ! Check all targets enqueued
         do i=1,size(targets)
 
-            if (.not.(targets(i)%ptr.in.queue)) then
+            if (.not.(targets(i)%ptr .in. queue)) then
 
                 call test_failed(error,"Target not found in build queue")
                 return

--- a/test/fpm_test/test_compiler.f90
+++ b/test/fpm_test/test_compiler.f90
@@ -27,6 +27,7 @@ contains
             & new_unittest("tokenize-flags", test_tokenize_flags), &
             & new_unittest("compile-commands-unix", test_register_compile_command_unix), &
             & new_unittest("compile-commands-windows", test_register_compile_command_windows), &
+            & new_unittest("compile-commands-executed-argv", test_register_executed_argv), &
             & new_unittest("get-default-flags-pic", test_get_default_flags_pic)]
 
     end subroutine collect_compiler
@@ -309,6 +310,66 @@ contains
             end if
         end associate
     end subroutine test_register_compile_command_windows
+
+    subroutine test_register_executed_argv(error)
+        type(error_t), allocatable, intent(out) :: error
+
+        type(compiler_t) :: compiler
+        type(compile_command_table_t) :: table
+        type(error_t), allocatable :: validation_error
+        type(string_t), allocatable :: empty(:), expected(:)
+        integer :: stat
+
+        compiler%fc = "gfortran"
+        compiler%echo = .false.
+        compiler%verbose = .false.
+
+        call compiler%compile_fortran("source dir/main.f90", "build dir/main.o", &
+            '-DNAME="two words" -I"include dir"', "", stat, table, dry_run=.true.)
+        if (stat /= 0) then
+            call test_failed(error, "Dry-run compile command registration failed")
+            return
+        end if
+
+        expected = [string_t("gfortran"), string_t("-c"), &
+            string_t("source dir/main.f90"), string_t("-DNAME=two words"), &
+            string_t("-Iinclude dir"), string_t("-o"), string_t("build dir/main.o")]
+
+        if (size(table%command) /= 1) then
+            call test_failed(error, "Expected one dry-run compile command")
+            return
+        end if
+        if (.not.table%command(1)%arguments == expected) then
+            call test_failed(error, "Registered arguments differ from executed argv")
+            return
+        end if
+        if (table%command(1)%file%s /= "source dir/main.f90") then
+            call test_failed(error, "Registered source differs from compiled input")
+            return
+        end if
+
+        allocate(empty(0))
+        call table%register(empty, "source dir/main.f90", validation_error)
+        if (.not.allocated(validation_error)) then
+            call test_failed(error, "Empty arguments should fail registration")
+            return
+        end if
+        if (size(table%command) /= 1) then
+            call test_failed(error, "Empty arguments changed the command table")
+            return
+        end if
+
+        call table%register(expected, "", validation_error)
+        if (.not.allocated(validation_error)) then
+            call test_failed(error, "Empty source should fail registration")
+            return
+        end if
+        if (size(table%command) /= 1) then
+            call test_failed(error, "Empty source changed the command table")
+            return
+        end if
+
+    end subroutine test_register_executed_argv
 
     subroutine test_get_default_flags_pic(error)
         !> Error handling

--- a/test/fpm_test/test_features.f90
+++ b/test/fpm_test/test_features.f90
@@ -3,10 +3,9 @@ module test_features
     use testsuite, only : new_unittest, unittest_t, error_t, test_failed
     use fpm_manifest, only: package_config_t, get_package_data
     use fpm_manifest_feature, only: feature_config_t
-    use fpm_manifest_feature_collection, only: feature_collection_t
     use fpm_manifest_platform, only: platform_config_t
     use fpm_environment, only: OS_ALL, OS_LINUX, OS_MACOS, OS_WINDOWS
-    use fpm_compiler, only: id_all, id_gcc, id_intel_classic_nix, id_intel_classic_windows, id_intel_llvm_nix, &
+    use fpm_compiler, only: id_gcc, id_intel_classic_nix, id_intel_llvm_nix, &
         match_compiler_type
     use fpm_strings, only: string_t
     use fpm_filesystem, only: get_temp_filename

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -3,7 +3,7 @@ module test_filesystem
     use fpm_filesystem, only: canon_path, is_dir, mkdir, os_delete_dir, &
                               join_path, is_absolute_path, get_home, &
                               delete_file, read_lines, get_temp_filename
-    use fpm_environment, only: OS_WINDOWS, get_os_type, os_is_unix
+    use fpm_environment, only: os_is_unix
     use fpm_strings, only: string_t, split_lines_first_last
     implicit none
     private

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -3,10 +3,7 @@ module test_manifest
     use fpm_filesystem, only: get_temp_filename
     use testsuite, only : new_unittest, unittest_t, error_t, test_failed, check_string
     use fpm_manifest
-    use fpm_manifest_profile, only: profile_config_t
-    use fpm_manifest_platform, only: platform_config_t
-    use fpm_compiler, only: id_gcc, id_intel_classic_nix
-    use fpm_environment, only: OS_LINUX
+    use fpm_compiler, only: id_gcc
     use fpm_manifest_feature, only: feature_config_t
     use fpm_strings, only: operator(.in.), string_t
     use fpm_error, only: fatal_error, error_t
@@ -237,7 +234,7 @@ contains
             return
         end if
 
-        if (.not.("include".in.package%library%include_dir)) then
+        if (.not.("include" .in. package%library%include_dir)) then
             call test_failed(error,"'include' not in default include-dir list")
             return
         end if
@@ -881,7 +878,7 @@ contains
             return
         end if
 
-        if (.not.("include".in.library%include_dir)) then
+        if (.not.("include" .in. library%include_dir)) then
             call test_failed(error,"'include' not in default include-dir list")
             return
         end if

--- a/test/fpm_test/test_module_dependencies.f90
+++ b/test/fpm_test/test_module_dependencies.f90
@@ -1,7 +1,7 @@
 !> Define tests for the `fpm_sources` module (module dependency checking)
 module test_module_dependencies
     use testsuite, only : new_unittest, unittest_t, error_t, test_failed
-    use fpm_targets, only: targets_from_sources, resolve_module_dependencies, &
+    use fpm_targets, only: targets_from_sources, &
                             build_target_t, build_target_ptr, &
                             FPM_TARGET_EXECUTABLE, FPM_TARGET_OBJECT, FPM_TARGET_ARCHIVE
     use fpm_model, only: fpm_model_t, srcfile_t,  &

--- a/test/fpm_test/test_os.f90
+++ b/test/fpm_test/test_os.f90
@@ -1,6 +1,6 @@
 module test_os
     use testsuite, only: new_unittest, unittest_t, error_t, test_failed
-    use fpm_filesystem, only: join_path, mkdir, os_delete_dir, is_dir, get_local_prefix, get_home
+    use fpm_filesystem, only: os_delete_dir, is_dir, get_home
     use fpm_environment, only: os_is_unix, get_env, set_env, delete_env
     use fpm_os, only: get_absolute_path, get_absolute_path_by_cd, get_current_directory
 

--- a/test/fpm_test/test_package_dependencies.f90
+++ b/test/fpm_test/test_package_dependencies.f90
@@ -1,6 +1,5 @@
 !> Define tests for the `fpm_dependency` module
 module test_package_dependencies
-  use fpm_filesystem, only: get_temp_filename
   use testsuite, only: new_unittest, unittest_t, error_t, test_failed
   use fpm_filesystem, only: is_dir, join_path, filewrite, mkdir, os_delete_dir, exists
   use fpm_environment, only: os_is_unix
@@ -8,9 +7,8 @@ module test_package_dependencies
   use fpm_dependency
   use fpm_manifest_dependency
   use fpm_manifest_metapackages, only: metapackage_config_t
-  use fpm_manifest, only: package_config_t, get_package_data
   use tomlf, only: toml_table, new_table
-  use fpm_toml, only: toml_key, add_table, set_value, get_value
+  use fpm_toml, only: toml_key, add_table, set_value
   use fpm_settings, only: fpm_global_settings, get_registry_settings, get_global_settings
   use fpm_downloader, only: downloader_t
   use fpm_versioning, only: version_t

--- a/test/fpm_test/test_runner.f90
+++ b/test/fpm_test/test_runner.f90
@@ -17,6 +17,7 @@ contains
 
         testsuite = [ &
             & new_unittest("run-executables-status", run_executables_status), &
+            & new_unittest("run-executables-windows-status", run_executables_windows_status), &
             & new_unittest("run-executables-parallel", run_executables_parallel) &
             ]
     end subroutine collect_runner
@@ -47,6 +48,34 @@ contains
 
         call os_delete_dir(os_is_unix(), dir)
     end subroutine run_executables_status
+
+    subroutine run_executables_windows_status(error)
+        type(error_t), allocatable, intent(out) :: error
+
+        type(fpm_test_settings) :: settings
+        type(string_t), allocatable :: executables(:)
+        integer, allocatable :: stat(:)
+        character(len=:), allocatable :: dir
+
+        if (os_is_unix()) return
+
+        call init_settings(settings)
+        settings%runner = 'cmd.exe /c'
+        call make_script_dir(dir)
+        call make_batch_script(dir, "pass.bat", 0)
+        call make_batch_script(dir, "fail.bat", 7)
+
+        executables = [string_t(dir//"/pass.bat"), string_t(dir//"/fail.bat")]
+        call run_executables(executables, settings, parallel=.true., stat=stat)
+
+        if (size(stat) /= 2) then
+            call test_failed(error, "wrong status count")
+        elseif (stat(1) /= 0 .or. stat(2) /= 7) then
+            call test_failed(error, "wrong run status values")
+        end if
+
+        call os_delete_dir(os_is_unix(), dir)
+    end subroutine run_executables_windows_status
 
     subroutine run_executables_parallel(error)
         type(error_t), allocatable, intent(out) :: error
@@ -115,5 +144,16 @@ contains
         close(unit)
         call run("chmod +x "//path, echo=.false., verbose=.false.)
     end subroutine make_script
+
+    subroutine make_batch_script(dir, name, status)
+        character(len=*), intent(in) :: dir, name
+        integer, intent(in) :: status
+
+        integer :: unit
+
+        open(newunit=unit, file=dir//"/"//name, status="replace")
+        write(unit, '(a,i0)') "@exit /b ", status
+        close(unit)
+    end subroutine make_batch_script
 
 end module test_runner

--- a/test/fpm_test/test_source_parsing.f90
+++ b/test/fpm_test/test_source_parsing.f90
@@ -6,8 +6,8 @@ module test_source_parsing
     use fpm_model, only: srcfile_t, FPM_UNIT_PROGRAM, FPM_UNIT_MODULE, &
                          FPM_UNIT_SUBMODULE, FPM_UNIT_SUBPROGRAM, FPM_UNIT_CSOURCE, &
                          FPM_UNIT_CPPSOURCE, FPM_UNIT_NAME
-    use fpm_strings, only: operator(.in.), lower, string_t
-    use fpm_error, only: file_parse_error, fatal_error
+    use fpm_strings, only: operator(.in.), string_t
+    use fpm_error, only: fatal_error
     use fpm_manifest_preprocess, only: preprocess_config_t
     implicit none
     private

--- a/test/fpm_test/test_toml.f90
+++ b/test/fpm_test/test_toml.f90
@@ -2,7 +2,7 @@
 module test_toml
     use testsuite, only : new_unittest, unittest_t, error_t
     use tomlf, only: toml_table, toml_load
-    use fpm_toml, only: read_package_file, toml_array, toml_key, toml_stat, &
+    use fpm_toml, only: read_package_file, &
         get_value, set_value, get_list, new_table, add_table, add_array, len, &
         toml_error, toml_serialize, check_keys, set_list, set_string, &
         name_is_json
@@ -21,12 +21,12 @@ module test_toml
     use fpm_manifest_metapackages, only: metapackage_config_t
     use fpm_manifest_feature_collection, only: feature_collection_t
     use fpm_manifest_profile, only: profile_config_t
-    use fpm_environment, only: OS_ALL, OS_LINUX, OS_MACOS
+    use fpm_environment, only: OS_LINUX, OS_MACOS
     use fpm_versioning, only: new_version
     use fpm_strings, only: string_t, operator(==), split
     use fpm_model, only: fortran_config_t, package_t, FPM_SCOPE_LIB, FPM_UNIT_MODULE, fpm_model_t, &
          & srcfile_t
-    use fpm_compiler, only: archiver_t, compiler_t, id_all, id_gcc
+    use fpm_compiler, only: archiver_t, compiler_t, id_gcc
     use fpm_error, only: fatal_error
 
 
@@ -560,7 +560,7 @@ contains
             call get_list(table, key="lorem-ipsum", list=copy, error=error)
             if (allocated(error)) return
 
-            if (.not.(list==copy)) then
+            if (.not.(list == copy)) then
                call fatal_error(error,'string_array is not equal after TOML roundtrip')
                return
             end if
@@ -580,7 +580,7 @@ contains
         call get_list(table, key="lorem-ipsum", list=copy, error=error)
         if (allocated(error)) return
 
-        if (.not.(list==copy)) then
+        if (.not.(list == copy)) then
            call fatal_error(error,'empty string_array is not equal after TOML roundtrip')
            return
         end if
@@ -596,7 +596,7 @@ contains
         call get_list(table, key="lorem-ipsum", list=copy, error=error)
         if (allocated(error)) return
 
-        if (.not.(list==copy)) then
+        if (.not.(list == copy)) then
            call fatal_error(error,'deallocated string_array is not equal after TOML roundtrip')
            return
         end if


### PR DESCRIPTION
Parallel Unix builds now serialize process creation and the small compiler-argv construction interval while leaving child waits and compiler execution concurrent. Compile-command registration copies the exact argv already sent to the compiler, avoiding a second non-reentrant lexer pass. The raw command parser remains available for fallback and public API use. Windows keeps its OpenMP and CreateProcess dispatch path.

The CI bootstrap and single-file patches now match the current feature manifest. GCC 10 through 13 select an explicit empty feature set because their static libgomp binaries fail during teardown. GCC 14 remains the shipped OpenMP artifact. Empty output-directory sentinels continue to mean the current directory and are no longer passed to mkdir.

Argument order, quoting, source-file identity, redirect behavior, child status propagation, Windows C bindings, target layout, and generated compiler invocations are preserved. The argv and source strings are copied into the compile-command table, so no caller-owned lifetime escapes.

## Verification

Failing before:
```text
GCC 14 OpenMP stdlib_extblas stress: 40/41 passed, then SIGSEGV in add_strings_one
Windows GCC CI: compile-commands-executed-argv used POSIX-only test quoting
GCC 11 default-feature static binary: exit 139 with GOMP linked
shared_app_only: mkdir failed for an empty output-directory sentinel
CI bootstrap: feature-table manifest rejected
source-single-file: patch did not apply
fo: 124 unused-import diagnostics
```

Passing after:
```text
GCC 14.4 OpenMP stdlib_extblas stress: 100/100 passed
OpenMPI metapackage script: 10/10 build and run cases passed
GCC 11 explicit-empty-feature static binary: exit 0, no GOMP symbols
shared_app_only: shared_lib [PASSED]

fo test
Tests: 4 passed

fo
Static: OK
Build: OK
Tests: 3/3
Lint: OK
All stages passed

MinGW: filesystem_utilities.c compiled and PE32+ harness linked
bootstrap.patch: apply/reverse PASS
single-file.patch: apply/reverse PASS
git diff --check: PASS
```